### PR TITLE
[feature/seller_list] 이벤트 목록 css 수정

### DIFF
--- a/components/event/Event.js
+++ b/components/event/Event.js
@@ -1,31 +1,79 @@
 import styled from '@emotion/styled';
-import { getTime } from '@utils/functions';
+import EVENET_STATE, { EVENT_STATE } from '@utils/constants/types';
+import { getTime, getState } from '@utils/functions';
 
 export default function Event({ event }) {
   console.log('EVENT');
 
   return (
-    <div className="event">
-      <a onClick={() => onClick(event.id)}>
-        <div>
-          <EventImage
-            src={event.eventImage.eventBannerImg}
-            alt={event.descript}
-          />
-        </div>
-        <div>
-          <p>
-            {event.type} | {event.title}
-          </p>
-          <p>
-            {getTime(event.startAt)} ~ {getTime(event.endAt)}
-          </p>
-        </div>
-      </a>
-    </div>
+    <>
+      <EventDiv>
+        <a>
+          <div>
+            <EventImage
+              src={event.eventImage.eventBannerImg}
+              alt={event.descript}
+            />
+          </div>
+          <Content>
+            <Left>{event.storeName}</Left>
+            <Right>{getState(EVENT_STATE, event.type)}</Right>
+            <br />
+            <br />
+            <Title>{event.title}</Title>
+            <Time>
+              {getTime(event.startAt)} ~<br /> {getTime(event.endAt)}
+            </Time>
+          </Content>
+        </a>
+      </EventDiv>
+    </>
   );
 }
 
+const EventDiv = styled.div`
+  display: inline-block;
+  height: 23rem;
+  width: 28rem;
+  margin: 1rem;
+  padding: 1rem;
+  border-radius: 1rem;
+  border: 1px solid #d6d6d6;
+`;
+
+const Content = styled.div`
+  padding: 1rem;
+`;
+
+const Title = styled.div`
+  font-size: 1.5rem;
+  font-weight: bold;
+`;
+
+const Left = styled.div`
+  font-weight: bold;
+  float: left;
+  margin: 0 auto;
+  font-size: 1.5rem;
+  color: #999;
+`;
+
+const Right = styled.div`
+  font-weight: bold;
+  float: right;
+  margin: 0 auto;
+  font-size: 1.5rem;
+  color: #999;
+`;
+
+const Time = styled.div`
+  margin-top: 0.5rem;
+  font-size: 1rem;
+`;
+
 const EventImage = styled.img`
-  width: 400px;
+  width: 25rem;
+  height: 10rem;
+  margin: auto;
+  margin-bottom: 1rem;
 `;

--- a/components/event/EventList.js
+++ b/components/event/EventList.js
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { GET_DATA } from '@apis/defaultApi';
 import Event from '@components/event/Event';
+import styled from '@emotion/styled';
 
 export default function EventList() {
   const [eventList, setEventList] = useState([]);
@@ -12,13 +13,14 @@ export default function EventList() {
   }, []);
 
   return (
-    <ul className="event-list">
-      {eventList &&
-        eventList.map((event) => (
-          <li key={event.id}>
-            <Event event={event} />
-          </li>
-        ))}
-    </ul>
+    <>
+      <List>
+        {eventList && eventList.map((event) => <Event event={event} />)}
+      </List>
+    </>
   );
 }
+
+const List = styled.div`
+  display: inline-block;
+`;

--- a/pages/event/index.js
+++ b/pages/event/index.js
@@ -1,7 +1,7 @@
 import CommerceLayout from '@components/common/CommerceLayout';
 import SiteHead from '@components/common/SiteHead.js';
 import EventList from '@components/event/EventList';
-import styles from '@styles/Home.module.scss';
+import styled from '@emotion/styled';
 
 export default function EventHome() {
   return (
@@ -9,11 +9,15 @@ export default function EventHome() {
       <SiteHead title="EventHome" />
       <section className="flex min-h-screen flex-col text-gray-600 body-font">
         <div className="container px-5 py-24 mx-auto">
-          <h1 className={styles.section}>THE PARABOLE</h1>
-          <h2 className={styles.section}>이벤트목록</h2>
+          <H1>이벤트목록</H1>
           <EventList />
         </div>
       </section>
     </CommerceLayout>
   );
 }
+
+const H1 = styled.div`
+  font-size: 2rem;
+  margin: 1rem;
+`;

--- a/pages/user/event/[id].js
+++ b/pages/user/event/[id].js
@@ -1,0 +1,35 @@
+import SiteHead from '@components/common/SiteHead.js';
+import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
+import CommerceLayout from '@components/common/CommerceLayout';
+import styled from '@emotion/styled';
+import EventList from '@components/event/EventList';
+
+export default function Event() {
+  const router = useRouter();
+  const [userId, setUserId] = useState(router.query.id);
+
+  useEffect(() => {
+    setUserId(router.query.id);
+  }, [router]);
+
+  return (
+    <>
+      <CommerceLayout>
+        <SiteHead title="EventList" />
+        <section className="flex min-h-screen flex-col text-gray-600 body-font">
+          <div className="container px-5 py-24 mx-auto">
+            <H1>이벤트 </H1>
+            <EventList userId={userId} />
+          </div>
+        </section>
+      </CommerceLayout>
+    </>
+  );
+}
+
+const H1 = styled.h1`
+  font-size: 30px;
+  margin-bottom: 30px;
+  font-family: 'SansBold';
+`;

--- a/utils/constants/types.js
+++ b/utils/constants/types.js
@@ -35,12 +35,17 @@ export const ORDER_STATE = [
 ];
 
 export const ORDER_PAY_STATE = [
-  { key: 'CARD', name: '카드결제' },
-  { key: 'BANK_TRANSFER', name: '실시간 계좌이체' },
-  { key: 'PHONE', name: '휴대폰결제' },
-  { key: 'VIRTUAL_ACCOUNT', name: '가상계좌' },
-  { key: 'KAKAO_PAY', name: '카카오페이' },
-  { key: 'TOSS', name: '토스' },
-  { key: 'WITHOUT_BANK', name: '무통장입금' },
-  { key: 'NAVER_PAY', name: '네이버페이' },
+  { value: 'CARD', name: '카드결제' },
+  { value: 'BANK_TRANSFER', name: '실시간 계좌이체' },
+  { value: 'PHONE', name: '휴대폰결제' },
+  { value: 'VIRTUAL_ACCOUNT', name: '가상계좌' },
+  { value: 'KAKAO_PAY', name: '카카오페이' },
+  { value: 'TOSS', name: '토스' },
+  { value: 'WITHOUT_BANK', name: '무통장입금' },
+  { value: 'NAVER_PAY', name: '네이버페이' },
+];
+
+export const EVENT_STATE = [
+  { value: 'RAFFLE', name: '래플 이벤트' },
+  { value: 'FCFS', name: '선착순 이벤트' },
 ];

--- a/utils/functions.js
+++ b/utils/functions.js
@@ -1,5 +1,3 @@
-import { ORDER_PAY_STATE, ORDER_STATE } from './constants/types';
-
 function getTime(str) {
   const getDate = str.split('T')[0];
   const date =
@@ -20,6 +18,7 @@ function getTime(str) {
 }
 
 function getState(state, prop) {
+  console.log(state, prop);
   const resultState = state.map((state) => {
     if (state.value === prop) return state.name;
   });


### PR DESCRIPTION
## 개요
이벤트 목록 css 수정과 utils/constants의 type과 function을 정리했습니다.

## 작업한 내용
구현한 이벤트 목록입니다.<br/>
![image](https://user-images.githubusercontent.com/21255149/196024284-5fd70e5a-0cc3-4e7a-b798-cb92a9823216.png)


## 리뷰 가이드
function에 FCFS와 RAFFLE을 name으로 반환하는 코드를 추가했습니다.
```
{getState(EVENT_STATE, event.type)}
```
이벤트 관련해서 타입을 가져오실 때 사용하시면 되겠습니다.

브랜치 이름이 잘못된 건 작업을 마무리 되고 나서 알았기 때문에 양해 부탁드리겠습니다.... 😢 

## 이슈번호
[#20]
