### PR TITLE
[feature/product-page] 상품 목록 페이지 구현

### DIFF
--- a/components/common/CommerceHeader.js
+++ b/components/common/CommerceHeader.js
@@ -4,6 +4,7 @@ import Link from 'next/link';
 
 const Links = {
   LINK_MAIN: '/',
+  LINK_PRODUCT: '/product',
   LINK_EVENT: '/event',
   LINK_SELLER_MAIN: '/seller/main',
   LINK_CART: '/user/cart',
@@ -27,7 +28,7 @@ export default function CommerceHeader() {
               </a>
             </Link>
             <nav className="md:mr-auto md:ml-10 flex flex-wrap items-center text-base justify-center">
-              <Link href={Links.LINK_MAIN}>
+              <Link href={Links.LINK_PRODUCT}>
                 <a className="mr-10 text-xl font-semibold hover:font-semibold hover:text-secondblue">
                   스토어
                 </a>

--- a/components/common/CustomSwiper.js
+++ b/components/common/CustomSwiper.js
@@ -1,0 +1,39 @@
+import { Swiper, SwiperSlide } from 'swiper/react';
+
+import 'swiper/css';
+import 'swiper/css/navigation';
+import 'swiper/css/pagination';
+
+import { Navigation, Pagination, Mousewheel, Keyboard } from 'swiper';
+
+export default function CustomSwiper() {
+  return (
+    <>
+      <Swiper
+        cssMode={true}
+        navigation={true}
+        pagination={true}
+        mousewheel={true}
+        keyboard={true}
+        modules={[Navigation, Pagination, Mousewheel, Keyboard]}
+        className="mySwiper"
+      >
+        <SwiperSlide>
+          <img src="https://image.ohou.se/i/bucketplace-v2-development/uploads/store/banners/store_home_banners/166573992584362130.png?gif=1&w=2560&q=100"></img>
+        </SwiperSlide>
+        <SwiperSlide>
+          <img src="https://image.ohou.se/i/bucketplace-v2-development/uploads/store/banners/store_home_banners/166597362662322690.png?gif=1&w=2560&q=100"></img>
+        </SwiperSlide>
+        <SwiperSlide>
+          <img src="https://image.ohou.se/i/bucketplace-v2-development/uploads/store/banners/store_home_banners/166605757286962706.png?gif=1&w=2560&q=100"></img>
+        </SwiperSlide>
+        <SwiperSlide>
+          <img src="https://image.ohou.se/i/bucketplace-v2-development/uploads/store/banners/store_home_banners/166573964522940796.jpg?gif=1&w=2560&q=100"></img>
+        </SwiperSlide>
+        <SwiperSlide>
+          <img src="https://image.ohou.se/i/bucketplace-v2-development/uploads/store/banners/store_home_banners/166573981678744789.png?gif=1&w=2560&q=100"></img>
+        </SwiperSlide>
+      </Swiper>
+    </>
+  );
+}

--- a/components/input/SearchBar.js
+++ b/components/input/SearchBar.js
@@ -1,11 +1,21 @@
 import styled from '@emotion/styled';
 import { ICON_SEARCH_MAGNIFY } from '@utils/constants/icons';
 import { useState } from 'react';
+import { useRouter } from 'next/router';
+
 const SearchBar = ({ placeholder, onKeyUp, onChange, onInput }) => {
   const [searchValue, setSearchValue] = useState('');
+  const router = useRouter();
 
-  const onClickHandler = (e) => {
+  const onClickHandler = () => {
+    router.push({ pathname: '/product', query: { searchValue: searchValue } });
+  };
+
+  const handleOnKeyPress = (e) => {
     e.preventDefault();
+    if (e.key === 'Enter') {
+      onClickHandler();
+    }
   };
 
   return (
@@ -16,6 +26,7 @@ const SearchBar = ({ placeholder, onKeyUp, onChange, onInput }) => {
           type="text"
           value={searchValue}
           onChange={(e) => setSearchValue(e.target.value)}
+          onKeyUp={handleOnKeyPress}
           placeholder={placeholder}
         />
       </InputDiv>

--- a/components/product/ProductList.js
+++ b/components/product/ProductList.js
@@ -1,9 +1,12 @@
 import Product from '@components/product/Product';
 import { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
 import { GET_DATA } from '@apis/defaultApi';
 import styled from '@emotion/styled';
 import Pagination from '@components/common/Pagination';
 import * as color from '@utils/constants/themeColor';
+import Link from 'next/link';
+
 const INIT_PAGENUM = 0;
 const INIT_SIZENUM = 20;
 
@@ -19,6 +22,8 @@ export default function ProductList({
   const [totalElementCnt, setTotalElementCnt] = useState(0);
   const [totalPages, setTotalPages] = useState(0);
   const [nowPage, setNowPage] = useState(page);
+
+  const isMainPage = useRouter().pathname === '/' ? true : false;
 
   useEffect(() => {
     GET_DATA(`/product/list`, {
@@ -50,15 +55,15 @@ export default function ProductList({
       <div className="max-w-screen-2xl px-4 md:px-8 mx-auto">
         <div className="flex justify-between items-end gap-4 mb-6">
           <h2 className="text-gray-800 text-2xl lg:text-3xl font-bold">
-            최신 상품
+            상품 목록
           </h2>
-
-          <a
-            href="#"
-            className="inline-block bg-white hover:bg-gray-100 active:bg-gray-200 focus-visible:ring ring-indigo-300 border text-gray-500 text-sm md:text-base font-semibold text-center rounded-lg outline-none transition duration-100 px-4 md:px-8 py-2 md:py-3"
-          >
-            보러가기
-          </a>
+          {isMainPage && (
+            <Link href="/product">
+              <a className="inline-block bg-white hover:bg-gray-100 active:bg-gray-200 focus-visible:ring ring-indigo-300 border text-gray-500 text-sm md:text-base font-semibold text-center rounded-lg outline-none transition duration-100 px-4 md:px-8 py-2 md:py-3">
+                보러가기
+              </a>
+            </Link>
+          )}
         </div>
         <div className="grid sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-x-4 md:gap-x-6 gap-y-8">
           {productList &&

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "axios": "^0.27.2",
         "next": "12.3.1",
         "react": "18.2.0",
-        "react-dom": "18.2.0"
+        "react-dom": "18.2.0",
+        "swiper": "^8.4.4"
       },
       "devDependencies": {
         "autoprefixer": "^10.4.12",
@@ -2167,6 +2168,14 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dom7": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/dom7/-/dom7-4.0.4.tgz",
+      "integrity": "sha512-DSSgBzQ4rJWQp1u6o+3FVwMNnT5bzQbMb+o31TjYYeRi05uAcpF8koxdfzeoe5ElzPmua7W7N28YJhF7iEKqIw==",
+      "dependencies": {
+        "ssr-window": "^4.0.0"
       }
     },
     "node_modules/ecc-jsbn": {
@@ -5873,6 +5882,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ssr-window": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/ssr-window/-/ssr-window-4.0.2.tgz",
+      "integrity": "sha512-ISv/Ch+ig7SOtw7G2+qkwfVASzazUnvlDTwypdLoPoySv+6MqlOV10VwPSE6EWkGjhW50lUmghPmpYZXMu/+AQ=="
+    },
     "node_modules/ssri": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.1.tgz",
@@ -6108,6 +6122,29 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/swiper": {
+      "version": "8.4.4",
+      "resolved": "https://registry.npmjs.org/swiper/-/swiper-8.4.4.tgz",
+      "integrity": "sha512-jA/8BfOZwT8PqPSnMX0TENZYitXEhNa7ZSNj1Diqh5LZyUJoBQaZcqAiPQ/PIg1+IPaRn/V8ZYVb0nxHMh51yw==",
+      "funding": [
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/swiperjs"
+        },
+        {
+          "type": "open_collective",
+          "url": "http://opencollective.com/swiper"
+        }
+      ],
+      "hasInstallScript": true,
+      "dependencies": {
+        "dom7": "^4.0.4",
+        "ssr-window": "^4.0.2"
+      },
+      "engines": {
+        "node": ">= 4.7.0"
       }
     },
     "node_modules/tailwindcss": {
@@ -8138,6 +8175,14 @@
       "dev": true,
       "requires": {
         "esutils": "^2.0.2"
+      }
+    },
+    "dom7": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/dom7/-/dom7-4.0.4.tgz",
+      "integrity": "sha512-DSSgBzQ4rJWQp1u6o+3FVwMNnT5bzQbMb+o31TjYYeRi05uAcpF8koxdfzeoe5ElzPmua7W7N28YJhF7iEKqIw==",
+      "requires": {
+        "ssr-window": "^4.0.0"
       }
     },
     "ecc-jsbn": {
@@ -10874,6 +10919,11 @@
         "tweetnacl": "~0.14.0"
       }
     },
+    "ssr-window": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/ssr-window/-/ssr-window-4.0.2.tgz",
+      "integrity": "sha512-ISv/Ch+ig7SOtw7G2+qkwfVASzazUnvlDTwypdLoPoySv+6MqlOV10VwPSE6EWkGjhW50lUmghPmpYZXMu/+AQ=="
+    },
     "ssri": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.1.tgz",
@@ -11060,6 +11110,15 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="
+    },
+    "swiper": {
+      "version": "8.4.4",
+      "resolved": "https://registry.npmjs.org/swiper/-/swiper-8.4.4.tgz",
+      "integrity": "sha512-jA/8BfOZwT8PqPSnMX0TENZYitXEhNa7ZSNj1Diqh5LZyUJoBQaZcqAiPQ/PIg1+IPaRn/V8ZYVb0nxHMh51yw==",
+      "requires": {
+        "dom7": "^4.0.4",
+        "ssr-window": "^4.0.2"
+      }
     },
     "tailwindcss": {
       "version": "3.1.8",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "axios": "^0.27.2",
     "next": "12.3.1",
     "react": "18.2.0",
-    "react-dom": "18.2.0"
+    "react-dom": "18.2.0",
+    "swiper": "^8.4.4"
   },
   "devDependencies": {
     "autoprefixer": "^10.4.12",

--- a/pages/product/index.js
+++ b/pages/product/index.js
@@ -1,0 +1,42 @@
+import styled from '@emotion/styled';
+
+import CommerceLayout from '@components/common/CommerceLayout';
+import SiteHead from '@components/common/SiteHead.js';
+import { useRouter } from 'next/router';
+import ProductList from '@components/product/ProductList';
+import CustomSwiper from '@components/common/CustomSwiper';
+export default function Products({}) {
+  const router = useRouter();
+
+  const inputSearchValue = router.query.searchValue;
+  const productListProps = {
+    size: 6,
+    page: 0,
+    productName: inputSearchValue,
+  };
+
+  return (
+    <>
+      <CommerceLayout>
+        <SiteHead title="Home" />
+        <div className="container px-5 py-12 mx-auto">
+          <CustomSwiper></CustomSwiper>
+          <Row>
+            <ProductList {...productListProps} />
+          </Row>
+        </div>
+      </CommerceLayout>
+    </>
+  );
+}
+
+const Row = styled.div`
+  display: flex;
+  justify-content: space-around;
+  flex-wrap: wrap;
+  box-sizing: border-box;
+  margin-right: -10px;
+  margin-left: -10px;
+  align-items: stretch;
+  margin-bottom: 40px;
+`;


### PR DESCRIPTION
## 개요
메인화면 외에 상품 목록만 보여주는 페이지 구현작업

## 작업한 내용
- 스와이프 라이브러리 설치 및 컴포넌트 추가 (현재 더미 이미지)
- 상품 목록 화면 
- 검색바 입력시 상품 목록 구현

## 리뷰 가이드
- `npm i` 로 라이브러리 설치해주세요
- 검색값이 잘 넘어가는지 확인해주세요

## 테스트 결과
- 상품 목록 페이지 
![image](https://user-images.githubusercontent.com/37797830/196396430-bb799515-c517-4ba6-9ec8-aa95cfbe0245.png)

- 검색바 입력값 + 상품 목록 페이지
![image](https://user-images.githubusercontent.com/37797830/196396600-4d7cd079-83a7-4981-b613-a90f112aa8e5.png)
