### PR TITLE
[feature/backendhost] HOTFIX: 마켓 백엔드 서버에서 API GATEWAY서버로 호스트 변경함

### DIFF
--- a/apis/api-config.js
+++ b/apis/api-config.js
@@ -1,12 +1,12 @@
 let backendHost;
 
 //const hostname = window && window.location && window.location.hostname;
-const hostname = 'prod';
+const hostname = 'dev';
 
 if (hostname === 'prod') {
   backendHost = 'http://localhost:8000';
 } else if (hostname === 'dev') {
-  backendHost = 'http://13.125.163.134';
+  backendHost = 'http://3.39.25.221:8000';
 } else {
   backendHost = 'http://localhost:8080';
 }


### PR DESCRIPTION
API 게이트웨이 설정 추가로 백엔드 호스트 주소를 변경하였습니다.
이제 마켓 백엔드 서버로 바로 요청보내면 CORS오류를 마주치게 됩니다..