### PR TITLE
[feature/login-redirect] 소셜 로그인 리다이렉트 주소 배포도메인으로

### DIFF
--- a/apis/api-config.js
+++ b/apis/api-config.js
@@ -13,3 +13,4 @@ if (hostname === 'prod') {
 
 export const API_BASE_URL = `${backendHost}/api/v1`;
 export const FRONT_BASE_URL = `http://localhost:3000`;
+export const FRONT_DEPLOY_URL = `http://theparabole.shop`;

--- a/pages/signin.js
+++ b/pages/signin.js
@@ -5,7 +5,7 @@ import SiteHead from '@components/common/SiteHead';
 import { POST } from '@apis/defaultApi';
 import Link from 'next/link';
 import { Blue } from '@components/input/Button';
-import { FRONT_BASE_URL } from '@apis/api-config';
+import { FRONT_BASE_URL, FRONT_DEPLOY_URL } from '@apis/api-config';
 import { LINKS } from '@utils/constants/links';
 
 export default function Signin() {
@@ -13,13 +13,13 @@ export default function Signin() {
   const [email, onChangeEmail] = useInput('');
   const [password, onChangePassword] = useInput('');
 
-  const GOOGLE_REDIRECT_URI = FRONT_BASE_URL + '/code/google';
+  const GOOGLE_REDIRECT_URI = FRONT_DEPLOY_URL + '/code/google';
   const GOOGLE_AUTH_URI = `${process.env.NEXT_PUBLIC_GOOGLE_AUTH}?client_id=${process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID}&redirect_uri=${GOOGLE_REDIRECT_URI}&response_type=code&scope=profile%20email%20openid`;
 
-  const KAKAO_REDIRECT_URI = FRONT_BASE_URL + '/code/kakao';
+  const KAKAO_REDIRECT_URI = FRONT_DEPLOY_URL + '/code/kakao';
   const KAKAO_AUTH_URI = `${process.env.NEXT_PUBLIC_KAKAO_AUTH}?client_id=${process.env.NEXT_PUBLIC_KAKAO_REST_API_KEY}&redirect_uri=${KAKAO_REDIRECT_URI}&response_type=code`;
 
-  const NAVER_REDIRECT_URI = FRONT_BASE_URL + '/code/naver';
+  const NAVER_REDIRECT_URI = FRONT_DEPLOY_URL + '/code/naver';
   const NAVER_AUTH_URI = `${process.env.NEXT_PUBLIC_NAVER_AUTH}?client_id=${process.env.NEXT_PUBLIC_NAVER_REST_API_KEY}&redirect_uri=${NAVER_REDIRECT_URI}&response_type=code&state=${process.env.NEXT_PUBLIC_NAVER_STATE}`;
 
   function handleSubmit(e) {


### PR DESCRIPTION
## 작업한 내용
 소셜 로그인 리다이렉트 주소 배포도메인으로 수정해놨습니다.
단, 도메인을 url 에 붙여놔야 동작 테스트 가능합니다.

