### PR TITLE
[Feature/couponListError] 판매자의 쿠폰 목록페이지와 쿠폰 배정 페이지 수정

### DIFF
--- a/components/common/CommerceHeader.js
+++ b/components/common/CommerceHeader.js
@@ -100,7 +100,7 @@ export default function CommerceHeader() {
         </HeaderSection>
       </header>
     );
-  } else if (resize >= 767) {
+  } else if (resize > 767) {
     return (
       <header className="body-font flex flex-col">
         <HeaderSection className="md:fixed w-full h-12 md:h-24 bg-white md:border-b md:border-gray-200 md:z-50">

--- a/components/common/CommerceHeaderMenuModal.js
+++ b/components/common/CommerceHeaderMenuModal.js
@@ -5,23 +5,34 @@ import { LINKS } from '@utils/constants/links';
 import { Blue, LineBlue } from '@components/input/Button';
 import { ICON_GIFT } from '@utils/constants/icons';
 import { ICON_BASKET } from '../../utils/constants/icons';
+import { useRouter } from 'next/router';
 
 export default function CommerceHeaderMenuModal({ closeModalFunc, token }) {
   const btnCss = { width: '100%' };
+
+  const router = useRouter();
 
   function CheckTocken({ token }) {
     if (token) {
       return (
         <MainButtonSection>
           <ButtonSection>
-            <Link href={LINKS.MYPAGE}>
-              <LineBlue buttonText={'마이페이지'} css={btnCss} />
-            </Link>
+            <LineBlue
+              buttonText={'마이페이지'}
+              css={btnCss}
+              onClickFunc={() => {
+                router.push(LINKS.MYPAGE);
+              }}
+            />
           </ButtonSection>
           <ButtonSection>
-            <Link href={LINKS.SIGNOUT}>
-              <Blue buttonText={'로그아웃'} css={btnCss} />
-            </Link>
+            <Blue
+              buttonText={'로그아웃'}
+              css={btnCss}
+              onClickFunc={() => {
+                router.push(LINKS.SIGNOUT);
+              }}
+            />
           </ButtonSection>
         </MainButtonSection>
       );
@@ -29,14 +40,22 @@ export default function CommerceHeaderMenuModal({ closeModalFunc, token }) {
       return (
         <MainButtonSection>
           <ButtonSection>
-            <Link href={LINKS.SIGNIN}>
-              <LineBlue buttonText={'로그인'} css={btnCss} />
-            </Link>
+            <LineBlue
+              buttonText={'로그인'}
+              css={btnCss}
+              onClickFunc={() => {
+                router.push(LINKS.SIGNIN);
+              }}
+            />
           </ButtonSection>
           <ButtonSection>
-            <Link href={LINKS.SIGNUP}>
-              <Blue buttonText={'회원가입'} css={btnCss} />
-            </Link>
+            <Blue
+              buttonText={'회원가입'}
+              css={btnCss}
+              onClickFunc={() => {
+                router.push(LINKS.SIGNUP);
+              }}
+            />
           </ButtonSection>
         </MainButtonSection>
       );

--- a/components/common/IconList.js
+++ b/components/common/IconList.js
@@ -15,7 +15,6 @@ export default function IconList() {
   return (
     <div className="flex flex-col items-centermt-8 md:mt-16">
       <div className="grid grid-cols-4 md:grid-cols-8 gap-x-4 lg:gap-x-10 gap-y-8 lg:gap-y-12 items-center">
-        {console.log(iconList)}
         {iconList.map((item) => (
           <div className="flex flex-col items-center" key={item.title}>
             <div className="md:w-24 md:h-24 bg-gray-100 rounded-full overflow-hidden shadow-lg mb-2 md:mb-4">

--- a/components/coupon/CouponAssignResult.js
+++ b/components/coupon/CouponAssignResult.js
@@ -1,0 +1,146 @@
+import styled from '@emotion/styled';
+import { LargeInput } from '@components/input/Input';
+import { ThemeGray5 } from '@utils/constants/themeColor';
+import { SmallPink } from '@components/input/Button';
+
+export default function CouponAssignResult({
+  selectedCoupon,
+  userParentList,
+  changeUserParentList,
+}) {
+  function handleChkChange(user) {
+    changeUserParentList({
+      userId: user.userId,
+      email: user.email,
+      phone: user.phone,
+      username: user.username,
+      flag: false,
+    });
+  }
+
+  function ShowCoupon() {
+    if (selectedCoupon !== 0) {
+      console.log('ShowCoupon', selectedCoupon);
+      let couponString =
+        selectedCoupon.name +
+        ' (' +
+        selectedCoupon.discountValue +
+        (selectedCoupon.type === 1 ? '% 할인쿠폰' : '₩ 할인쿠폰') +
+        ')';
+
+      return (
+        <LabelInputSection>
+          <LargeInput
+            type="text"
+            attr={{ readOnly: true }}
+            css={{ width: '100%' }}
+            value={couponString}
+          />
+        </LabelInputSection>
+      );
+    } else {
+      return (
+        <LabelInputSection>
+          <LargeInput
+            type="text"
+            attr={{ readOnly: true }}
+            css={{ width: '100%' }}
+            value={'쿠폰을 선택해주세요'}
+          />
+        </LabelInputSection>
+      );
+    }
+  }
+
+  function ShowUser() {
+    console.log('CouponAssignResult-showUser', userParentList);
+    if (userParentList.length > 0) {
+      return (
+        userParentList &&
+        userParentList.map((user) => (
+          <tr
+            key={user.userId}
+            className="bg-white border-b dark:bg-gray-800 dark:border-gray-700 px-6"
+          >
+            <td className="py-4 px-6">{user.username}</td>
+            <td className="py-4 px-6">{user.email}</td>
+            <td className="py-4 px-6">{user.phone}</td>
+            <td className="py-4 px-6">
+              <SmallPink
+                buttonText={'제거'}
+                onClickFunc={() => {
+                  handleChkChange(user);
+                }}
+              />
+            </td>
+          </tr>
+        ))
+      );
+    } else {
+      return (
+        <tr>
+          <EmptyTd colSpan={4}>
+            <span>{'사용자를 선택해주세요'}</span>
+          </EmptyTd>
+        </tr>
+      );
+    }
+  }
+
+  return (
+    <div>
+      <LabelSection>
+        <LabelTitle>선택된 쿠폰</LabelTitle>
+        <ShowCoupon selectedCoupon={selectedCoupon} />
+      </LabelSection>
+      <LabelTitle>선택된 사용자</LabelTitle>
+      <UserTableSection>
+        <table className="w-full text-sm text-left text-gray-500 dark:text-gray-400">
+          <thead className="text-xs text-gray-700 uppercase bg-gray-50 dark:bg-gray-700 dark:text-gray-400">
+            <tr>
+              <th className="py-3 px-6">사용자명</th>
+              <th className="py-3 px-6">이메일</th>
+              <th className="py-3 px-6">전화번호</th>
+              <th className="py-3 px-6">제거</th>
+            </tr>
+          </thead>
+          <tbody>
+            <ShowUser userParentList={userParentList} />
+          </tbody>
+        </table>
+      </UserTableSection>
+    </div>
+  );
+}
+
+const LabelSection = styled.div`
+  display: flex;
+  width: 100%;
+  padding: 20px 0;
+`;
+
+const LabelTitle = styled.span`
+  margin-left: auto;
+  font-size: 1.1rem;
+  width: 30%;
+`;
+
+const LabelInputSection = styled.span`
+  display: inline-flex;
+  width: 70%;
+`;
+
+const UserTableSection = styled.div`
+  margin-top: 10px;
+  max-height: 400px;
+  overflow: auto;
+`;
+
+const EmptyTd = styled.td`
+  text-align: center;
+  font-size: larger;
+  font-style: bold;
+  padding: 30px;
+  background-color: ${ThemeGray5};
+  color: black;
+`;

--- a/components/coupon/CouponAssignResult.js
+++ b/components/coupon/CouponAssignResult.js
@@ -20,7 +20,6 @@ export default function CouponAssignResult({
 
   function ShowCoupon() {
     if (selectedCoupon !== 0) {
-      console.log('ShowCoupon', selectedCoupon);
       let couponString =
         selectedCoupon.name +
         ' (' +
@@ -53,7 +52,6 @@ export default function CouponAssignResult({
   }
 
   function ShowUser() {
-    console.log('CouponAssignResult-showUser', userParentList);
     if (userParentList.length > 0) {
       return (
         userParentList &&

--- a/components/coupon/CouponList.js
+++ b/components/coupon/CouponList.js
@@ -15,7 +15,7 @@ function Coupon({ coupon }) {
       </th>
       <td className="py-4 px-6">{coupon.type === 1 ? '정액' : '정률'}</td>
       <td className="py-4 px-6">
-        {coupon.discountValue} {coupon.type === 1 ? '&' : '₩'}
+        {coupon.discountValue} {coupon.type === 1 ? '%' : '₩'}
       </td>
 
       <td className="py-4 px-6">{coupon.detail}</td>
@@ -66,7 +66,7 @@ function CouponList() {
                 쿠폰 타입
               </th>
               <th scope="col" className="py-3 px-6">
-                할인율/액수
+                할인율/금액
               </th>
               <th scope="col" className="py-3 px-6">
                 쿠폰 상세설명

--- a/components/coupon/CouponList.js
+++ b/components/coupon/CouponList.js
@@ -13,9 +13,9 @@ function Coupon({ coupon }) {
       >
         {coupon.name}
       </th>
-      <td className="py-4 px-6">{coupon.type === 1 ? '할인금액' : '할인율'}</td>
+      <td className="py-4 px-6">{coupon.type === 1 ? '정액' : '정률'}</td>
       <td className="py-4 px-6">
-        {coupon.discountValue} {coupon.type === 1 ? '원' : '%'}
+        {coupon.discountValue} {coupon.type === 1 ? '&' : '₩'}
       </td>
 
       <td className="py-4 px-6">{coupon.detail}</td>

--- a/components/coupon/CouponListRadio.js
+++ b/components/coupon/CouponListRadio.js
@@ -1,41 +1,87 @@
 import { GET_DATA } from '@apis/defaultApi';
-import * as btn from '@components/input/Button';
-import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 import styled from '@emotion/styled';
-import { useGetToken } from '@hooks/useGetToken';
+import { ThemeGray5 } from '@utils/constants/themeColor';
 
-function CouponListRadio({ sellerId, setCouponParentId, headers }) {
-  const router = useRouter();
+export default function CouponListRadio({ changeCouponParentId, headers }) {
   const [couponList, setCouponList] = useState([]);
   const [totalElementCnt, setTotalElementCnt] = useState(0);
 
-  const [radioValue, setRadioValue] = useState(1);
+  const [radioValue, setRadioValue] = useState(0);
 
   useEffect(() => {
-    let headers = useGetToken();
-    GET_DATA(`/coupon/seller/list`, '', headers).then((res) => {
-      if (res) {
-        if (res.numberOfElements === 0) {
-          alert('판매자가 등록한 쿠폰이 없습니다.');
-        } else if (res.content) {
-          setCouponList(res.content);
-          setTotalElementCnt(res.numberOfElements);
+    if (headers !== '') {
+      GET_DATA(`/coupon/seller/list`, '', headers).then((res) => {
+        if (res) {
+          if (res.numberOfElements === 0) {
+            alert('판매자가 등록한 쿠폰이 없습니다.');
+          } else if (res.content) {
+            setCouponList(res.content);
+            setTotalElementCnt(res.numberOfElements);
+          }
+        } else {
+          alert('판매자의 쿠폰을 조회하지 못했습니다. 다시 시도해주세요.');
         }
-      } else {
-        alert('판매자의 쿠폰을 조회하지 못했습니다. 다시 시도해주세요.');
-      }
-    });
-  }, []);
+      });
+    }
+  }, [headers]);
 
-  function handleRadioChange(e) {
-    setRadioValue(e.target.value);
-    setCouponParentId(e.target.value);
+  function handleRadioChange(coupon) {
+    console.log('handleRadioChange', coupon, coupon.couponId);
+    changeCouponParentId(coupon);
+    setRadioValue(coupon.couponId);
+  }
+
+  function ShowCoupon() {
+    if (couponList.length > 0) {
+      return (
+        couponList &&
+        couponList.map((coupon) => (
+          <tr
+            key={coupon.couponId}
+            className="bg-white border-b dark:bg-gray-800 dark:border-gray-700"
+          >
+            <th
+              scope="row"
+              className="py-4 px-6 font-medium text-gray-900 whitespace-nowrap dark:text-white"
+            >
+              <input
+                id={coupon.couponId}
+                type="radio"
+                name="list-radio"
+                value={coupon.couponId}
+                checked={radioValue === coupon.couponId}
+                onChange={() => {
+                  handleRadioChange(coupon);
+                }}
+                className="w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 focus:ring-blue-500 dark:focus:ring-blue-600 dark:ring-offset-gray-700 focus:ring-2 dark:bg-gray-600 dark:border-gray-500 mr-3"
+              />
+              {coupon.name}
+            </th>
+            <td className="py-4 px-6">
+              {coupon.type === 0 ? '정액(₩)' : '정률(%)'}
+            </td>
+            <td className="py-4 px-6">{coupon.discountValue}</td>
+            <td className="py-4 px-6">{coupon.detail}</td>
+            <td className="py-4 px-6">{coupon.cnt}</td>
+            <td className="py-4 px-6">{coupon.remains}</td>
+          </tr>
+        ))
+      );
+    } else {
+      return (
+        <tr>
+          <EmptyTd colSpan={6}>
+            <span>{'쿠폰을 생성해주세요'}</span>
+          </EmptyTd>
+        </tr>
+      );
+    }
   }
 
   return (
     <div>
-      <div className="overflow-x-auto relative">
+      <CouponTableSection className="overflow-x-auto relative">
         <table className="w-full text-sm text-left text-gray-500 dark:text-gray-400">
           <thead className="text-xs text-gray-700 uppercase bg-gray-50 dark:bg-gray-700 dark:text-gray-400">
             <tr>
@@ -60,59 +106,32 @@ function CouponListRadio({ sellerId, setCouponParentId, headers }) {
             </tr>
           </thead>
           <tbody>
-            {couponList &&
-              couponList.map((coupon) => (
-                // <CouponChk key={coupon.couponId} coupon={coupon} />
-                <tr
-                  key={coupon.couponId}
-                  className="bg-white border-b dark:bg-gray-800 dark:border-gray-700"
-                >
-                  <th
-                    scope="row"
-                    className="py-4 px-6 font-medium text-gray-900 whitespace-nowrap dark:text-white"
-                  >
-                    {/* <Chk type="checkbox" /> */}
-                    <input
-                      id="coupon-radio"
-                      type="radio"
-                      value={coupon.couponId}
-                      name="list-radio"
-                      onChange={handleRadioChange}
-                      className="w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 focus:ring-blue-500 dark:focus:ring-blue-600 dark:ring-offset-gray-700 focus:ring-2 dark:bg-gray-600 dark:border-gray-500 mr-3"
-                    />
-                    {coupon.name}
-                  </th>
-                  <td className="py-4 px-6">
-                    {coupon.type === 1 ? '할인액 (원)' : '할인율 (%)'}
-                  </td>{' '}
-                  <td className="py-4 px-6">{coupon.discountValue}</td>
-                  <td className="py-4 px-6">{coupon.detail}</td>
-                  <td className="py-4 px-6">{coupon.cnt}</td>
-                  <td className="py-4 px-6">{coupon.remains}</td>
-                </tr>
-              ))}
+            <ShowCoupon />
           </tbody>
         </table>
-      </div>
-      <br />
-      <strong>
-        <p>총 쿠폰 수량 : {totalElementCnt}</p>
-      </strong>
-      <btn.Pink
-        onClickFunc={() => router.push('./new')}
-        buttonText="쿠폰 등록하기"
-        css={{
-          width: '30%',
-          float: 'right',
-          marginLeft: '3%',
-        }}
-      />
+      </CouponTableSection>
+      <ResultSection>
+        <p>보유 쿠폰 종류 : {totalElementCnt} 개</p>
+      </ResultSection>
     </div>
   );
 }
 
-export default CouponListRadio;
+const CouponTableSection = styled.div`
+  max-height: 400px;
+  overflow: auto;
+`;
 
-const Chk = styled.input`
-  margin-right: 8px;
+const EmptyTd = styled.td`
+  text-align: center;
+  font-size: larger;
+  font-style: bold;
+  padding: 30px;
+  background-color: ${ThemeGray5};
+  color: black;
+`;
+
+const ResultSection = styled.div`
+  margin-top: 10px;
+  text-align: right;
 `;

--- a/components/coupon/CouponListRadio.js
+++ b/components/coupon/CouponListRadio.js
@@ -90,7 +90,7 @@ export default function CouponListRadio({ changeCouponParentId, headers }) {
                 쿠폰 타입
               </th>
               <th scope="col" className="py-3 px-6">
-                할인율/액수
+                할인율/금액
               </th>
               <th scope="col" className="py-3 px-6">
                 발급 수량(총 수량)

--- a/components/coupon/CouponListRadio.js
+++ b/components/coupon/CouponListRadio.js
@@ -27,7 +27,6 @@ export default function CouponListRadio({ changeCouponParentId, headers }) {
   }, [headers]);
 
   function handleRadioChange(coupon) {
-    console.log('handleRadioChange', coupon, coupon.couponId);
     changeCouponParentId(coupon);
     setRadioValue(coupon.couponId);
   }

--- a/components/coupon/CouponListRadio.js
+++ b/components/coupon/CouponListRadio.js
@@ -61,7 +61,6 @@ export default function CouponListRadio({ changeCouponParentId, headers }) {
               {coupon.type === 0 ? '정액(₩)' : '정률(%)'}
             </td>
             <td className="py-4 px-6">{coupon.discountValue}</td>
-            <td className="py-4 px-6">{coupon.detail}</td>
             <td className="py-4 px-6">{coupon.cnt}</td>
             <td className="py-4 px-6">{coupon.remains}</td>
           </tr>
@@ -92,9 +91,6 @@ export default function CouponListRadio({ changeCouponParentId, headers }) {
               </th>
               <th scope="col" className="py-3 px-6">
                 할인율/액수
-              </th>
-              <th scope="col" className="py-3 px-6">
-                쿠폰 상세설명
               </th>
               <th scope="col" className="py-3 px-6">
                 발급 수량(총 수량)

--- a/components/coupon/UserSearchBar.js
+++ b/components/coupon/UserSearchBar.js
@@ -1,16 +1,15 @@
 import { GET_DATA } from '@apis/defaultApi';
 import { useState } from 'react';
-import * as btn from '@components/input/Button';
 import useInput from '@hooks/useInput';
 import Input from '@components/input/Input';
-import Heading from '@components/input/Heading';
 import React from 'react';
+import { SmallPink } from '@components/input/Button';
+import styled from '@emotion/styled';
+import { ThemeGray5 } from '@utils/constants/themeColor';
 
-function UserSearchBar({ setUserParentList }) {
-  const [userName, onChangeUserName] = useInput('');
+export default function UserSearchBar({ changeUserParentList }) {
   const [userList, setUserList] = useState([]);
-
-  var checkedUsers = [];
+  const [userName, onChangeUserName] = useInput('');
 
   function onSearchUserHandler(e) {
     e.preventDefault();
@@ -28,67 +27,96 @@ function UserSearchBar({ setUserParentList }) {
     });
   }
 
-  function arrayRemove(arr, value) {
-    return arr.filter(function (element) {
-      return element != value;
+  function handleChkChange(user) {
+    changeUserParentList({
+      userId: user.userId,
+      email: user.email,
+      phone: user.phone,
+      username: user.username,
+      flag: true,
     });
   }
 
-  function handleChkChange(e) {
-    if (e.target.checked) {
-      checkedUsers.push(e.target.value);
-    } else if (!e.target.checked) {
-      checkedUsers = arrayRemove(checkedUsers, e.target.value);
+  function ShowUser() {
+    if (userList.length > 0) {
+      return (
+        userList &&
+        userList.map((user) => (
+          <tr
+            key={user.userId}
+            className="bg-white border-b dark:bg-gray-800 dark:border-gray-700 px-6"
+          >
+            <td className="py-4 px-6">{user.username}</td>
+            <td className="py-4 px-6">{user.email}</td>
+            <td className="py-4 px-6">{user.phone}</td>
+            <td className="py-4 px-6">
+              <SmallPink
+                buttonText={'추가'}
+                onClickFunc={() => {
+                  handleChkChange(user);
+                }}
+              />
+            </td>
+          </tr>
+        ))
+      );
+    } else {
+      return (
+        <tr>
+          <EmptyTd colSpan={4}>
+            <span>{'사용자를 검색해주세요'}</span>
+          </EmptyTd>
+        </tr>
+      );
     }
-    setUserParentList(checkedUsers);
   }
 
   return (
     <div>
-      <Heading title="쿠폰 배정할 사용자 검색창" type="h2" />
-      <Input
-        type="text"
-        attr={{ placeholder: '사용자명을 입력하세요' }}
-        onChange={onChangeUserName}
-        css={{ width: '49%', marginRight: '1.5%' }}
-      ></Input>
-      <btn.SmallPink buttonText="검색" onClickFunc={onSearchUserHandler} />
-
-      <table className="w-full text-sm text-left text-gray-500 dark:text-gray-400">
-        <thead className="text-xs text-gray-700 uppercase bg-gray-50 dark:bg-gray-700 dark:text-gray-400">
-          <tr>
-            <th className="py-3 px-6">사용자명</th>
-            <th className="py-3 px-6">이메일</th>
-            <th className="py-3 px-6">전화번호</th>
-          </tr>
-        </thead>
-        <tbody>
-          {userList &&
-            userList.map((user) => (
-              // <UserSearchResult key={user.userId} user={user} />
-              <tr
-                key={user.userId}
-                className="bg-white border-b dark:bg-gray-800 dark:border-gray-700"
-              >
-                <td className="py-4 px-6">
-                  <input
-                    id="user-checkbox"
-                    type="checkbox"
-                    value={user.userId}
-                    name="list-checkbox"
-                    onClick={handleChkChange}
-                    className="mr-3"
-                  />
-                  {user.username}
-                </td>
-                <td className="py-4 px-6">{user.email}</td>
-                <td className="py-4 px-6">{user.phone}</td>
-              </tr>
-            ))}
-        </tbody>
-      </table>
+      <UserInputSection>
+        <Input
+          type="text"
+          attr={{ placeholder: '사용자명을 입력하세요' }}
+          onChange={onChangeUserName}
+          css={{ width: '49%', marginRight: '1.5%' }}
+        />
+        <SmallPink buttonText="검색" onClickFunc={onSearchUserHandler} />
+      </UserInputSection>
+      <UserTableSection>
+        <table className="w-full text-sm text-left text-gray-500 dark:text-gray-400">
+          <thead className="text-xs text-gray-700 uppercase bg-gray-50 dark:bg-gray-700 dark:text-gray-400">
+            <tr>
+              <th className="py-3 px-6">사용자명</th>
+              <th className="py-3 px-6">이메일</th>
+              <th className="py-3 px-6">전화번호</th>
+              <th className="py-3 px-6">추가</th>
+            </tr>
+          </thead>
+          <tbody>
+            <ShowUser />
+          </tbody>
+        </table>
+      </UserTableSection>
     </div>
   );
 }
 
-export default UserSearchBar;
+const UserInputSection = styled.div`
+  text-align: right;
+  margin-left: auto;
+  padding: 20px;
+`;
+
+const UserTableSection = styled.div`
+  max-height: 400px;
+  overflow: auto;
+`;
+
+const EmptyTd = styled.td`
+  text-align: center;
+  font-size: larger;
+  font-style: bold;
+  padding: 30px;
+  background-color: ${ThemeGray5};
+  color: black;
+`;

--- a/pages/seller/coupon/assign.js
+++ b/pages/seller/coupon/assign.js
@@ -1,57 +1,102 @@
-import SiteHead from '@components/common/SiteHead.js';
-import { GET, POST, POST_DATA } from '@apis/defaultApi';
 import { useEffect, useState } from 'react';
-import CouponListRadio from '@components/coupon/CouponListRadio';
-import styled from '@emotion/styled';
-import UserSearchBar from '@components/coupon/UserSearchBar';
 import { useRouter } from 'next/router';
-import SellerLayout from '@components/seller/SellerLayout';
-import * as btn from '@components/input/Button';
-import Heading from '@components/input/Heading';
+import styled from '@emotion/styled';
+import { POST } from '@apis/defaultApi';
 import { useGetToken } from '@hooks/useGetToken';
+import { LINKS } from '@utils/constants/links';
+import { Pink, SmallPink } from '@components/input/Button';
+import Heading from '@components/input/Heading';
+import SiteHead from '@components/common/SiteHead.js';
+import SellerLayout from '@components/seller/SellerLayout';
+import CouponListRadio from '@components/coupon/CouponListRadio';
+import UserSearchBar from '@components/coupon/UserSearchBar';
+import CouponAssignResult from '@components/coupon/CouponAssignResult';
+import { ThemeGray4 } from '@utils/constants/themeColor';
 
 export default function CouponAssign() {
   const router = useRouter();
+  const [headers, setHeaders] = useState('');
+  const [couponParentId, setCouponParentId] = useState(0);
+  const [userParentList, setUserParentList] = useState([]);
 
-  const [headers, setHeaders] = useState();
   useEffect(() => {
     if (typeof window !== 'undefined' && typeof window !== undefined) {
       if (localStorage.getItem('userId') === null) {
         alert('로그인 해주세요.');
-        router.push('/signin');
+        router.push(LINKS.SIGNIN);
       } else if (localStorage.getItem('role') === 'ROLE_USER') {
         alert('판매자 페이지입니다.');
-        router.push('/');
+        router.push(LINKS.MAIN);
       }
     }
     setHeaders(useGetToken());
   }, []);
 
-  const [couponParentId, setCouponParentId] = useState();
-  const [userParentList, setUserParentList] = useState([]);
+  function changeUserParentList({ userId, email, phone, username, flag }) {
+    let list = [];
+    if (flag) {
+      list = [...userParentList, { userId, email, phone, username }];
+    } else {
+      userParentList.forEach((user) => {
+        if (user.userId !== userId) {
+          list = [
+            ...list,
+            {
+              userId: user.userId,
+              email: user.email,
+              phone: user.phone,
+              username: user.username,
+            },
+          ];
+        }
+      });
+    }
+    setUserParentList(list);
+  }
 
-  function assignCoupon(e) {
+  function changeCouponParentId(coupon) {
+    setCouponParentId(coupon);
+  }
+
+  function assignCoupon() {
+    if (couponParentId === 0) {
+      alert('쿠폰을 선택해주세요');
+      return;
+    }
+
+    if (userParentList.length === 0) {
+      alert('사용자를 선택해주세요');
+      return;
+    }
+
+    let userIdList = [];
+
+    userParentList.forEach((user) => {
+      userIdList = [...userIdList, user.userId];
+    });
+
     const reqBody = {
-      couponId: couponParentId,
-      userIdList: userParentList,
+      couponId: couponParentId.couponId,
+      userIdList,
     };
 
-    console.log(reqBody.userIdList);
+    console.log('assignCoupon', reqBody);
     POST(`/coupon/assign`, reqBody)
       .then((res) => {
         if (res.success) {
           alert('선택한 사용자에게 쿠폰이 정상적으로 지급되었습니다.');
+          router.reload();
+        } else if (res.message) {
+          alert('쿠폰을 배정에 실패했습니다. - ' + res.message);
+        } else {
+          alert('쿠폰 배정에 실패했습니다. - ', res);
         }
-        router.reload();
       })
-      .catch(function (error) {
-        return {};
+      .catch((e) => {
+        console.log(e);
+        alert('쿠폰 배정에 실패했습니다. 다시 시도해주세요');
       });
   }
-
-  // const sellerProps = {
-  //   sellerId: sellerId,
-  // };
 
   return (
     <>
@@ -59,20 +104,39 @@ export default function CouponAssign() {
         <SiteHead title="Seller's Coupon List" />
         <Heading title="쿠폰 배정" type="h1" />
         <PageContainer>
-          <Split>
+          <CouponListSection>
+            <Heading title="쿠폰 선택" type="h2" />
+            <ButtonSection>
+              <SmallPink
+                onClickFunc={() => router.push('./new')}
+                buttonText="새 쿠폰 등록"
+                css={{
+                  marginLeft: 'auto',
+                  marginBottom: '10px',
+                }}
+              />
+            </ButtonSection>
             <CouponListRadio
-              // {...sellerProps}
-              // sellerId={sellerId}
-              setCouponParentId={setCouponParentId}
-              // headers={headers}
-            ></CouponListRadio>
-          </Split>
-          <Split>
-            <UserSearchBar
-              setUserParentList={setUserParentList}
-            ></UserSearchBar>
-            <btn.SmallPink buttonText="쿠폰 배정" onClickFunc={assignCoupon} />
-          </Split>
+              changeCouponParentId={changeCouponParentId}
+              headers={headers}
+            />
+          </CouponListSection>
+          <UserListSection>
+            <Heading title="사용자 선택" type="h2" />
+            <UserSearchBar changeUserParentList={changeUserParentList} />
+          </UserListSection>
+          <ResultSection>
+            <Heading title="쿠폰 배정" type="h2" />
+            <CouponAssignResult
+              selectedCoupon={couponParentId}
+              userParentList={userParentList}
+              changeUserParentList={changeUserParentList}
+            />
+          </ResultSection>
+
+          <ButtonSection>
+            <Pink buttonText="쿠폰 배정" onClickFunc={assignCoupon} />
+          </ButtonSection>
         </PageContainer>
       </SellerLayout>
     </>
@@ -81,11 +145,28 @@ export default function CouponAssign() {
 
 const PageContainer = styled.div`
   display: flex;
-  flex-direction: row;
+  flex-direction: column;
   justify-content: center;
+  padding-top: 10px;
 `;
 
-const Split = styled.div`
-  flex: 1;
+const CouponListSection = styled.div`
+  border-radius: 5px;
+  border: 1px solid ${ThemeGray4};
+  padding: 2rem;
+  margin-bottom: 20px;
+`;
+
+const UserListSection = styled.div`
+  border-radius: 5px;
+  border: 1px solid ${ThemeGray4};
   padding: 1rem;
+`;
+
+const ResultSection = styled.div`
+  padding: 1rem;
+`;
+
+const ButtonSection = styled.div`
+  text-align: right;
 `;

--- a/pages/seller/coupon/assign.js
+++ b/pages/seller/coupon/assign.js
@@ -69,10 +69,10 @@ export default function CouponAssign() {
       return;
     }
 
-    let userIdList = [];
+    let userIdList = new Array();
 
     userParentList.forEach((user) => {
-      userIdList = [...userIdList, user.userId];
+      userIdList.push(user.userId);
     });
 
     const reqBody = {

--- a/pages/seller/coupon/assign.js
+++ b/pages/seller/coupon/assign.js
@@ -80,7 +80,6 @@ export default function CouponAssign() {
       userIdList,
     };
 
-    console.log('assignCoupon', reqBody);
     POST(`/coupon/assign`, reqBody)
       .then((res) => {
         if (res.success) {


### PR DESCRIPTION
## 개요

판매자의 쿠폰 목록페이지와 쿠폰 배정 페이지 수정

## 작업한 내용

## 리뷰 가이드

### 쿠폰 선택 로직 변경

<img width="998" alt="image" src="https://user-images.githubusercontent.com/52902010/201469921-cdd9c4b6-f71b-4991-925f-d8465a1a7bf4.png">

- 쿠폰 선택 ui 배치 수정
- 쿠폰 없을 시 추가 요청 메시지 추가
- radio버튼 동작 로직 수정
- 선택한 쿠폰의 id 정보 외에도 쿠폰 전체 정보 저장하도록 수정
- 표 크기가 무한하게 커지지 않도록 css 적용

### 사용자 추가/제거 로직 변경

<img width="1042" alt="image" src="https://user-images.githubusercontent.com/52902010/201469728-0d1115b8-3ee9-48ac-965f-9af06d273c01.png">

- 사용자 선택 ui 배치 수정
- 사용자 검색 요청 메시지 추가
- 사용자 추가 및 제거 로직 버튼으로 동작하도록 수정
- 선택한 사용자 id 외에도 사용자 전체 정보 저장하도록 수정
- 표 크기가 무한하게 커지지 않도록 css 적용

### 배정 최종확인 창 추가

- 선택 안했을때 상태 

<img width="983" alt="image" src="https://user-images.githubusercontent.com/52902010/201470017-a63dd672-6261-4664-893e-ac1223de374c.png">

- 선택했을때 상태

<img width="974" alt="image" src="https://user-images.githubusercontent.com/52902010/201470130-747ccdc2-3952-4d91-8e50-9539cd6153e5.png">

- 정보 추가 요청 메시지 적용
- 사용자 추가 및 제거 로직 버튼으로 동작하도록 수정
- 표 크기가 무한하게 커지지 않도록 css 적용

## 테스트 결과

<img width="1536" alt="image" src="https://user-images.githubusercontent.com/52902010/201470168-68d1e2d1-fd2a-42e8-9d1f-1961dbefc5e1.png">



