### PR TITLE
[feature/product-search] 스토어 화면, 상품 검색시 화면 수정

### DIFF
--- a/components/product/ProductList.js
+++ b/components/product/ProductList.js
@@ -26,6 +26,8 @@ export default function ProductList({
   const [nowPage, setNowPage] = useState(page);
 
   const [store, setStore] = useState();
+  const [storeId, setStoreId] = useState();
+
   const router = useRouter();
   const isMainPage = router.pathname === '/' ? true : false;
 
@@ -48,6 +50,7 @@ export default function ProductList({
           setTotalPages(res.totalPages);
           setNowPage(res.pageable.pageNumber);
           setStore(res.content[0].storeName);
+          setStoreId(res.content[0].sellerId);
         }
       } else {
         alert('상품을 찾을 수 없습니다. 다시 시도해주세요.');
@@ -61,7 +64,7 @@ export default function ProductList({
         {router.pathname.includes("store") &&
           (
             <div>
-              <StoreInfo total={totalElementCnt} products={productList} store={store}/>
+              <StoreInfo total={totalElementCnt} storeId={storeId} storeName={store}/>
            </div>   
           )
         }

--- a/components/product/ProductList.js
+++ b/components/product/ProductList.js
@@ -7,7 +7,7 @@ import Pagination from '@components/common/Pagination';
 import { BlueTheme } from '@utils/constants/themeColor';
 import Link from 'next/link';
 import { LINKS } from '@utils/constants/links';
-
+import StoreInfo from '@components/store/storeInfo';
 const INIT_PAGENUM = 0;
 const INIT_SIZENUM = 12;
 
@@ -25,7 +25,9 @@ export default function ProductList({
   const [totalPages, setTotalPages] = useState(0);
   const [nowPage, setNowPage] = useState(page);
 
-  const isMainPage = useRouter().pathname === '/' ? true : false;
+  const [store, setStore] = useState();
+  const router = useRouter();
+  const isMainPage = router.pathname === '/' ? true : false;
 
   useEffect(() => {
     GET_DATA(`/product/list`, {
@@ -38,7 +40,6 @@ export default function ProductList({
       sort: sort,
     }).then((res) => {
       if (res) {
-        console.log(res);
         if (res.numberOfElements === 0) {
           alert('상품이 없습니다.');
         } else if (res.content) {
@@ -46,6 +47,7 @@ export default function ProductList({
           setProductList(res.content);
           setTotalPages(res.totalPages);
           setNowPage(res.pageable.pageNumber);
+          setStore(res.content[0].storeName);
         }
       } else {
         alert('상품을 찾을 수 없습니다. 다시 시도해주세요.');
@@ -56,10 +58,26 @@ export default function ProductList({
   return (
     <div className="bg-white py-6 sm:py-8 lg:py-12">
       <div className="max-w-screen-2xl px-4 md:px-8 mx-auto">
+        {router.pathname.includes("store") &&
+          (
+            <div>
+              <StoreInfo total={totalElementCnt} products={productList} store={store}/>
+           </div>   
+          )
+        }
+        {router.query.searchValue && (
+          <div className='my-4 h-24'>
+            <div className='p-6 border rounded-sm border-gray-100'>
+              <div className="flex flex-row justify-center">
+                <p className="place-self-center text-gray-800 font-bold text-2xl lg:text-3xl">{router.query.searchValue}</p>
+                <p className="place-self-center text-gray-500 font-semibold text-xl lg:text-2xl">에 대한 검색결과</p>            
+              </div>
+            </div>
+          </div>
+        )}
+
         <div className="flex justify-between items-end gap-4 mb-6">
-          <h2 className="text-gray-800 text-2xl lg:text-3xl font-bold">
-            상품 목록
-          </h2>
+
           {isMainPage && (
             <Link href={LINKS.PRODUCT}>
               <a className="inline-block bg-white hover:bg-gray-100 active:bg-gray-200 focus-visible:ring ring-indigo-300 border text-gray-500 text-sm md:text-base font-semibold text-center rounded-lg outline-none transition duration-100 px-4 md:px-8 py-2 md:py-3">

--- a/components/product/ProductList.js
+++ b/components/product/ProductList.js
@@ -61,26 +61,31 @@ export default function ProductList({
   return (
     <div className="bg-white py-6 sm:py-8 lg:py-12">
       <div className="max-w-screen-2xl px-4 md:px-8 mx-auto">
-        {router.pathname.includes("store") &&
-          (
-            <div>
-              <StoreInfo total={totalElementCnt} storeId={storeId} storeName={store}/>
-           </div>   
-          )
-        }
+        {router.pathname.includes('store') && (
+          <div>
+            <StoreInfo
+              total={totalElementCnt}
+              storeId={storeId}
+              storeName={store}
+            />
+          </div>
+        )}
         {router.query.searchValue && (
-          <div className='my-4 h-24'>
-            <div className='p-6 border rounded-sm border-gray-100'>
+          <div className="my-4 h-24">
+            <div className="p-6 border rounded-sm border-gray-100">
               <div className="flex flex-row justify-center">
-                <p className="place-self-center text-gray-800 font-bold text-2xl lg:text-3xl">{router.query.searchValue}</p>
-                <p className="place-self-center text-gray-500 font-semibold text-xl lg:text-2xl">에 대한 검색결과</p>            
+                <p className="place-self-center text-gray-800 font-bold text-2xl lg:text-3xl">
+                  {router.query.searchValue}
+                </p>
+                <p className="place-self-center text-gray-500 font-semibold text-xl lg:text-2xl">
+                  에 대한 검색결과
+                </p>
               </div>
             </div>
           </div>
         )}
 
         <div className="flex justify-between items-end gap-4 mb-6">
-
           {isMainPage && (
             <Link href={LINKS.PRODUCT}>
               <a className="inline-block bg-white hover:bg-gray-100 active:bg-gray-200 focus-visible:ring ring-indigo-300 border text-gray-500 text-sm md:text-base font-semibold text-center rounded-lg outline-none transition duration-100 px-4 md:px-8 py-2 md:py-3">

--- a/components/store/StoreInfo.js
+++ b/components/store/StoreInfo.js
@@ -2,24 +2,16 @@ import { ColorBlue2 } from "@utils/constants/themeColor"
 import { LineBlue } from '@components/input/Button';
 import { ICON_SHOP } from '@utils/constants/icons';
 import { useEffect, useState } from "react";
-import { useRouter } from "next/router";
 import { GET_DATA } from "@apis/defaultApi";
 import CouponListModal from '@components/coupon/CouponListModal';
 
 export default function StoreInfo({
-  total, products, store
+  total, storeId, storeName
 }) {
-  const [storeId, setStoreId] = useState();
   const [modalState, setModalState] = useState(false);
   const [coupons, setCoupons] = useState([]);
 
-  const router = useRouter();
-  console.log('store', router);
-
   useEffect(() => {
-    if (router.query.id) {
-      setStoreId(router.query.id);
-    }
     if (storeId) {
       GET_DATA(`/coupon/store`, {sellerId : storeId}).then((res) => {
         if (res) {
@@ -28,8 +20,7 @@ export default function StoreInfo({
         }
       });
     }
-
-  }, [router.query]);
+  }, [storeId]);
     
     
 
@@ -48,10 +39,9 @@ export default function StoreInfo({
 
               <div>
                 <img src={ICON_SHOP}/>
-                <span className="text-gray-800 text-xl md:text-2xl lg:text-4xl font-bold mb-4">{store}</span>
+                <span className="text-gray-800 text-xl md:text-2xl lg:text-4xl font-bold mb-4">{storeName}</span>
               </div>
               <p className="max-w-md text-gray-600 mb-8">총 상품 : {total}개</p>
-
 
               <div className="flex py-2">
                 <LineBlue
@@ -61,13 +51,13 @@ export default function StoreInfo({
                 />
               </div>
               <div>
-                  {modalState && (
-                    <CouponListModal
-                      setModalState={setModalState}
-                      couponList={coupons}
-                      storeName={store}
-                    />
-                  )}
+                {modalState && (
+                  <CouponListModal
+                    setModalState={setModalState}
+                    couponList={coupons}
+                    storeName={storeName}
+                  />
+                )}
               </div>
             </div>
           </div>

--- a/components/store/StoreInfo.js
+++ b/components/store/StoreInfo.js
@@ -1,19 +1,17 @@
-import { ColorBlue2 } from "@utils/constants/themeColor"
+import { ColorBlue2 } from '@utils/constants/themeColor';
 import { LineBlue } from '@components/input/Button';
 import { ICON_SHOP } from '@utils/constants/icons';
-import { useEffect, useState } from "react";
-import { GET_DATA } from "@apis/defaultApi";
+import { useEffect, useState } from 'react';
+import { GET_DATA } from '@apis/defaultApi';
 import CouponListModal from '@components/coupon/CouponListModal';
 
-export default function StoreInfo({
-  total, storeId, storeName
-}) {
+export default function StoreInfo({ total, storeId, storeName }) {
   const [modalState, setModalState] = useState(false);
   const [coupons, setCoupons] = useState([]);
 
   useEffect(() => {
     if (storeId) {
-      GET_DATA(`/coupon/store`, {sellerId : storeId}).then((res) => {
+      GET_DATA(`/coupon/store`, { sellerId: storeId }).then((res) => {
         if (res) {
           console.log(res);
           setCoupons(res.content);
@@ -21,8 +19,6 @@ export default function StoreInfo({
       });
     }
   }, [storeId]);
-    
-    
 
   function showBenefitModal(e) {
     e.preventDefault();
@@ -36,18 +32,19 @@ export default function StoreInfo({
         <div className="max-w-screen-2xl mx-auto">
           <div className="p-4 md:h-80 flex flex-col sm:flex-row bg-blue-50 rounded-lg overflow-hidden">
             <div className="w-full sm:w-1/2 lg:w-3/5 flex flex-col p-4 sm:p-8">
-
               <div>
-                <img src={ICON_SHOP}/>
-                <span className="text-gray-800 text-xl md:text-2xl lg:text-4xl font-bold mb-4">{storeName}</span>
+                <img src={ICON_SHOP} />
+                <span className="text-gray-800 text-xl md:text-2xl lg:text-4xl font-bold mb-4">
+                  {storeName}
+                </span>
               </div>
               <p className="max-w-md text-gray-600 mb-8">총 상품 : {total}개</p>
 
               <div className="flex py-2">
                 <LineBlue
-                    buttonText="스토어 혜택을 받아보세요!"
-                    onClickFunc={(e) => showBenefitModal(e)}
-                    css={{ width: '60%', fontWeight: 'bold', }}
+                  buttonText="스토어 혜택을 받아보세요!"
+                  onClickFunc={(e) => showBenefitModal(e)}
+                  css={{ width: '60%', fontWeight: 'bold' }}
                 />
               </div>
               <div>
@@ -62,7 +59,7 @@ export default function StoreInfo({
             </div>
           </div>
         </div>
-      </div>    
+      </div>
     </>
-  )
+  );
 }

--- a/components/store/StoreInfo.js
+++ b/components/store/StoreInfo.js
@@ -1,0 +1,78 @@
+import { ColorBlue2 } from "@utils/constants/themeColor"
+import { LineBlue } from '@components/input/Button';
+import { ICON_SHOP } from '@utils/constants/icons';
+import { useEffect, useState } from "react";
+import { useRouter } from "next/router";
+import { GET_DATA } from "@apis/defaultApi";
+import CouponListModal from '@components/coupon/CouponListModal';
+
+export default function StoreInfo({
+  total, products, store
+}) {
+  const [storeId, setStoreId] = useState();
+  const [modalState, setModalState] = useState(false);
+  const [coupons, setCoupons] = useState([]);
+
+  const router = useRouter();
+  console.log('store', router);
+
+  useEffect(() => {
+    if (router.query.id) {
+      setStoreId(router.query.id);
+    }
+    if (storeId) {
+      GET_DATA(`/coupon/store`, {sellerId : storeId}).then((res) => {
+        if (res) {
+          console.log(res);
+          setCoupons(res.content);
+        }
+      });
+    }
+
+  }, [router.query]);
+    
+    
+
+  function showBenefitModal(e) {
+    e.preventDefault();
+
+    setModalState(true);
+  }
+
+  return (
+    <>
+      <div className="bg-white pb-4">
+        <div className="max-w-screen-2xl mx-auto">
+          <div className="p-4 md:h-80 flex flex-col sm:flex-row bg-blue-50 rounded-lg overflow-hidden">
+            <div className="w-full sm:w-1/2 lg:w-3/5 flex flex-col p-4 sm:p-8">
+
+              <div>
+                <img src={ICON_SHOP}/>
+                <span className="text-gray-800 text-xl md:text-2xl lg:text-4xl font-bold mb-4">{store}</span>
+              </div>
+              <p className="max-w-md text-gray-600 mb-8">총 상품 : {total}개</p>
+
+
+              <div className="flex py-2">
+                <LineBlue
+                    buttonText="스토어 혜택을 받아보세요!"
+                    onClickFunc={(e) => showBenefitModal(e)}
+                    css={{ width: '60%', fontWeight: 'bold', }}
+                />
+              </div>
+              <div>
+                  {modalState && (
+                    <CouponListModal
+                      setModalState={setModalState}
+                      couponList={coupons}
+                      storeName={store}
+                    />
+                  )}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>    
+    </>
+  )
+}

--- a/pages/product/[id].js
+++ b/pages/product/[id].js
@@ -86,7 +86,6 @@ export default function ProductDetail() {
               router.push(LINKS.CART);
             }
           } else {
-            console.log(res);
             alert(res.data.message);
           }
         } else {

--- a/pages/seller/product/[id].js
+++ b/pages/seller/product/[id].js
@@ -10,7 +10,6 @@ import EventParticipantList from '@components/event/EventParticipantList';
 import { useGetToken } from '@hooks/useGetToken';
 
 export default function SellerProductDetail() {
-  // TODO: userId를 가져올 때 저장되어있는 걸(cookie, localstorage)로 가져오게 변경
   const router = useRouter();
   const [userId, setUserId] = useState(router.query.id);
   const [name, setName] = useState();

--- a/pages/store/[id].js
+++ b/pages/store/[id].js
@@ -28,7 +28,6 @@ export default function store() {
       <SiteHead title="판매자 페이지" />
       <section className="flex min-h-screen flex-col text-gray-600 body-font">
         <div className="container px-5 py-24 mx-auto">
-          <span>판매자 화면</span>
           <div>
             <ProductList {...productListProps} />
           </div>


### PR DESCRIPTION
## 개요
상품 검색 결과 화면, 스토어 화면이 다른 상품 목록 화면과 큰 차이가 없어 사용자에게 혼란을 줄 것같아 화면을 수정했습니다.

## 작업한 내용
- 상품 검색 시 검색 키워드 표현
- 브랜드홈에서 스토어이름, 상품 개수, 쿠폰 조회할 수 있는 컴포넌트 추가

![image](https://user-images.githubusercontent.com/37797830/201521176-b529c0ff-1a6a-4751-b882-1f1be5ade321.png)
![image](https://user-images.githubusercontent.com/37797830/201521181-8aa2d06d-8c43-49fa-ba6c-4d1dd6723655.png)
