### PR TITLE
[feature/popup] 커스텀 팝업/알림 구현

### DIFF
--- a/components/cart/CartContentDetail.js
+++ b/components/cart/CartContentDetail.js
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import { DELETE } from '@apis/defaultApi';
 import { ThemeGray1 } from '@utils/constants/themeColor';
 import CartProduct from '@components/cart/CartProduct';
+import { confirmAlert } from 'react-confirm-alert';
 
 export default function CartContentDetail({
   headers,
@@ -56,14 +57,28 @@ export default function CartContentDetail({
     display: flex;
   `;
 
+  
   const deleteCartItem = ({ input }) => {
     const CartItemDeleteRequestDto = {
       cartItemId: input,
     };
-    if (confirm('장바구니에서 삭제하시겠습니까?')) {
-      DELETE(`/cart/delete`, CartItemDeleteRequestDto, headers);
-      router.reload();
-    }
+
+    confirmAlert({
+      title: "장바구니에서 삭제하시겠습니까?",
+      buttons: [
+        {
+          label: '네',
+          onClick: () => {
+            DELETE(`/cart/delete`, CartItemDeleteRequestDto, headers);
+            router.reload();
+          }
+        },
+        {
+          label: '아니오',
+          onClick: () => { return false; }
+        }
+      ]
+    });
   };
 
   return (

--- a/components/cart/CartContentDetail.js
+++ b/components/cart/CartContentDetail.js
@@ -57,27 +57,28 @@ export default function CartContentDetail({
     display: flex;
   `;
 
-  
   const deleteCartItem = ({ input }) => {
     const CartItemDeleteRequestDto = {
       cartItemId: input,
     };
 
     confirmAlert({
-      title: "장바구니에서 삭제하시겠습니까?",
+      title: '장바구니에서 삭제하시겠습니까?',
       buttons: [
         {
           label: '네',
           onClick: () => {
             DELETE(`/cart/delete`, CartItemDeleteRequestDto, headers);
             router.reload();
-          }
+          },
         },
         {
           label: '아니오',
-          onClick: () => { return false; }
-        }
-      ]
+          onClick: () => {
+            return false;
+          },
+        },
+      ],
     });
   };
 

--- a/components/cart/CartHeader.js
+++ b/components/cart/CartHeader.js
@@ -2,6 +2,9 @@ import { useRouter } from 'next/router';
 import styled from '@emotion/styled';
 import { DELETE } from '@apis/defaultApi';
 import { SmallLineWhite } from '@components/input/Button';
+import Toast from '@components/common/ToastPopup';
+import { toast } from 'react-toastify';
+import { confirmAlert } from 'react-confirm-alert'; // Import
 
 export default function CartHeader({
   totalCheckBoxChange,
@@ -39,12 +42,28 @@ export default function CartHeader({
     flex: 0 0 auto;
   `;
 
+  function confirmDelete (msg) {
+    confirmAlert({
+      title: msg,
+      buttons: [
+        {
+          label: '네',
+          onClick: () => { return true; }
+        },
+        {
+          label: '아니오',
+          onClick: () => { return false; }
+        }
+      ]
+    });
+  }
+
   const deleteCheckedItemBtn = () => {
     let deleteFlag = false;
     if (
       cartBySellerDtoList &&
       numberOfChekced !== 0 &&
-      confirm('선택한 상품을 장바구니에서 삭제하시겠습니까?')
+      confirmDelete('선택한 상품을 장바구니에서 삭제하시겠습니까?')
     ) {
       cartBySellerDtoList.map((dto) => {
         const cartItemList = dto.cartItemDtoList;
@@ -62,7 +81,7 @@ export default function CartHeader({
         router.reload();
       }
     } else {
-      alert('상품을 선택해주세요');
+      toast.warn('상품을 선택해주세요');
     }
   };
 
@@ -86,6 +105,7 @@ export default function CartHeader({
               deleteCheckedItemBtn();
             }}
           />
+          <Toast/>
         </CommerceCartHeaderRight>
       </CommerceCartHeaderContainerChild>
     </CommerceCartHeaderContainer>

--- a/components/cart/CartHeader.js
+++ b/components/cart/CartHeader.js
@@ -44,7 +44,7 @@ export default function CartHeader({
 
   function confirmDelete (msg) {
     confirmAlert({
-      title: msg,
+      title: "선택한 상품을 장바구니에서 삭제하시겠습니까?",
       buttons: [
         {
           label: '네',
@@ -62,24 +62,38 @@ export default function CartHeader({
     let deleteFlag = false;
     if (
       cartBySellerDtoList &&
-      numberOfChekced !== 0 &&
-      confirmDelete('선택한 상품을 장바구니에서 삭제하시겠습니까?')
+      numberOfChekced !== 0
     ) {
-      cartBySellerDtoList.map((dto) => {
-        const cartItemList = dto.cartItemDtoList;
-        cartItemList.map((item) => {
-          if (checkBoxStates.get(item.cartItemId)) {
-            const CartItemDeleteRequestDto = {
-              cartItemId: item.cartItemId,
-            };
-            DELETE(`/cart/delete`, CartItemDeleteRequestDto, headers);
-            deleteFlag = true;
+
+      confirmAlert({
+        title: "선택한 상품을 장바구니에서 삭제하시겠습니까?",
+        buttons: [
+          {
+            label: '네',
+            onClick: () => {
+              cartBySellerDtoList.map((dto) => {
+                const cartItemList = dto.cartItemDtoList;
+                cartItemList.map((item) => {
+                  if (checkBoxStates.get(item.cartItemId)) {
+                    const CartItemDeleteRequestDto = {
+                      cartItemId: item.cartItemId,
+                    };
+                    DELETE(`/cart/delete`, CartItemDeleteRequestDto, headers);
+                    deleteFlag = true;
+                  }
+                });
+              });
+              if (deleteFlag) {
+                router.reload();
+              }
+            }
+          },
+          {
+            label: '아니오',
+            // onClick: () => { return false; }
           }
-        });
+        ]
       });
-      if (deleteFlag) {
-        router.reload();
-      }
     } else {
       toast.warn('상품을 선택해주세요');
     }

--- a/components/cart/CartHeader.js
+++ b/components/cart/CartHeader.js
@@ -42,31 +42,31 @@ export default function CartHeader({
     flex: 0 0 auto;
   `;
 
-  function confirmDelete (msg) {
+  function confirmDelete(msg) {
     confirmAlert({
-      title: "선택한 상품을 장바구니에서 삭제하시겠습니까?",
+      title: '선택한 상품을 장바구니에서 삭제하시겠습니까?',
       buttons: [
         {
           label: '네',
-          onClick: () => { return true; }
+          onClick: () => {
+            return true;
+          },
         },
         {
           label: '아니오',
-          onClick: () => { return false; }
-        }
-      ]
+          onClick: () => {
+            return false;
+          },
+        },
+      ],
     });
   }
 
   const deleteCheckedItemBtn = () => {
     let deleteFlag = false;
-    if (
-      cartBySellerDtoList &&
-      numberOfChekced !== 0
-    ) {
-
+    if (cartBySellerDtoList && numberOfChekced !== 0) {
       confirmAlert({
-        title: "선택한 상품을 장바구니에서 삭제하시겠습니까?",
+        title: '선택한 상품을 장바구니에서 삭제하시겠습니까?',
         buttons: [
           {
             label: '네',
@@ -86,13 +86,13 @@ export default function CartHeader({
               if (deleteFlag) {
                 router.reload();
               }
-            }
+            },
           },
           {
             label: '아니오',
             // onClick: () => { return false; }
-          }
-        ]
+          },
+        ],
       });
     } else {
       toast.warn('상품을 선택해주세요');
@@ -119,7 +119,7 @@ export default function CartHeader({
               deleteCheckedItemBtn();
             }}
           />
-          <Toast/>
+          <Toast />
         </CommerceCartHeaderRight>
       </CommerceCartHeaderContainerChild>
     </CommerceCartHeaderContainer>

--- a/components/common/CommerceHeader.js
+++ b/components/common/CommerceHeader.js
@@ -10,8 +10,11 @@ import {
 import { LINKS } from '@utils/constants/links';
 import SearchBar from '@components/input/SearchBar';
 import CommerceHeaderMenuModal from '@components/common/CommerceHeaderMenuModal';
+import Toast from '@components/common/ToastPopup';
+import { toast } from 'react-toastify';
 
 export default function CommerceHeader() {
+
   const [token, setToken] = useState();
   const [resize, setResize] = useState();
   const [menuModalState, setMenuModalState] = useState(false);
@@ -53,6 +56,7 @@ export default function CommerceHeader() {
   if (resize >= 1024) {
     return (
       <header className="body-font flex flex-col">
+        <Toast/>
         <HeaderSection className="md:fixed w-full h-12 md:h-24 bg-white md:border-b md:border-gray-200 md:z-50">
           <HeaderContainer className="container mx-auto flex flex-wrap p-5 flex-col md:flex-row items-center">
             <Link href={LINKS.MAIN}>
@@ -103,6 +107,7 @@ export default function CommerceHeader() {
   } else if (resize >= 767) {
     return (
       <header className="body-font flex flex-col">
+        <Toast/>
         <HeaderSection className="md:fixed w-full h-12 md:h-24 bg-white md:border-b md:border-gray-200 md:z-50">
           <HeaderContainer className="container mx-auto flex flex-wrap p-5 flex-col md:flex-row items-center">
             <Link href={LINKS.MAIN}>
@@ -160,6 +165,7 @@ export default function CommerceHeader() {
   } else {
     return (
       <header className="body-font flex flex-col">
+        <Toast/>
         <MobileHeaderSection className="md:fixed w-full h-12 md:h-24 bg-white md:border-b md:border-gray-200 md:z-50">
           <HeaderContainer className="container mx-auto ">
             <MobileMenuSection>
@@ -216,7 +222,8 @@ function CheckTocken({ token }) {
 
   const signout = () => {
     localStorage.clear();
-    alert('로그아웃 완료');
+    toast.warn("로그아웃 완료 !");
+    
     router.push(LINKS.MAIN);
   };
 

--- a/components/common/ToastPopup.js
+++ b/components/common/ToastPopup.js
@@ -14,6 +14,5 @@ export default function Toast() {
       pauseOnHover
       theme="light"
     />
-
-  )
+  );
 }

--- a/components/common/ToastPopup.js
+++ b/components/common/ToastPopup.js
@@ -1,0 +1,19 @@
+import { ToastContainer, toast } from 'react-toastify';
+
+export default function Toast() {
+  return (
+    <ToastContainer
+      position="top-center"
+      autoClose={500}
+      hideProgressBar
+      newestOnTop={false}
+      closeOnClick
+      rtl={false}
+      pauseOnFocusLoss
+      draggable
+      pauseOnHover
+      theme="light"
+    />
+
+  )
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,9 @@
         "axios": "^0.27.2",
         "next": "12.3.1",
         "react": "18.2.0",
+        "react-confirm-alert": "^3.0.6",
         "react-dom": "18.2.0",
+        "react-toastify": "^9.1.1",
         "swiper": "^8.4.4"
       },
       "devDependencies": {
@@ -5831,6 +5833,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-confirm-alert": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/react-confirm-alert/-/react-confirm-alert-3.0.6.tgz",
+      "integrity": "sha512-rplP6Ed9ZSNd0KFV5BUzk4EPQ77BxsrayllBXGFuA8xPXc7sbBjgU5KUrNpl7aWFmP7mXRlVXfuy1IT5DbffYw==",
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=10.0.0"
+      }
+    },
     "node_modules/react-dom": {
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
@@ -5847,6 +5858,18 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "node_modules/react-toastify": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-9.1.1.tgz",
+      "integrity": "sha512-pkFCla1z3ve045qvjEmn2xOJOy4ZciwRXm1oMPULVkELi5aJdHCN/FHnuqXq8IwGDLB7PPk2/J6uP9D8ejuiRw==",
+      "dependencies": {
+        "clsx": "^1.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
+      }
     },
     "node_modules/react-transition-group": {
       "version": "4.4.5",
@@ -11430,6 +11453,12 @@
         "loose-envify": "^1.1.0"
       }
     },
+    "react-confirm-alert": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/react-confirm-alert/-/react-confirm-alert-3.0.6.tgz",
+      "integrity": "sha512-rplP6Ed9ZSNd0KFV5BUzk4EPQ77BxsrayllBXGFuA8xPXc7sbBjgU5KUrNpl7aWFmP7mXRlVXfuy1IT5DbffYw==",
+      "requires": {}
+    },
     "react-dom": {
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
@@ -11443,6 +11472,14 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "react-toastify": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-9.1.1.tgz",
+      "integrity": "sha512-pkFCla1z3ve045qvjEmn2xOJOy4ZciwRXm1oMPULVkELi5aJdHCN/FHnuqXq8IwGDLB7PPk2/J6uP9D8ejuiRw==",
+      "requires": {
+        "clsx": "^1.1.1"
+      }
     },
     "react-transition-group": {
       "version": "4.4.5",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
     "axios": "^0.27.2",
     "next": "12.3.1",
     "react": "18.2.0",
+    "react-confirm-alert": "^3.0.6",
     "react-dom": "18.2.0",
+    "react-toastify": "^9.1.1",
     "swiper": "^8.4.4"
   },
   "devDependencies": {

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -2,6 +2,8 @@ import styled from '@emotion/styled';
 import '@styles/globals.scss';
 import { Html } from 'next/document';
 import 'pages/app.css';
+import 'react-toastify/dist/ReactToastify.min.css';
+import 'react-confirm-alert/src/react-confirm-alert.css';
 
 function MyApp({ Component, pageProps }) {
   return (

--- a/pages/product/[id].js
+++ b/pages/product/[id].js
@@ -10,6 +10,9 @@ import CommerceLayout from '@components/common/CommerceLayout';
 import SiteHead from '@components/common/SiteHead.js';
 import { SmallLineWhite, LineBlue, Blue } from '@components/input/Button';
 import Input from '@components/input/Input';
+import { confirmAlert } from 'react-confirm-alert';
+import { toast } from 'react-toastify';
+import Toast from '@components/common/ToastPopup';
 
 export default function ProductDetail() {
   const router = useRouter();
@@ -47,10 +50,26 @@ export default function ProductDetail() {
   function isCountValid() {
     if (count > maxCount || count < minCount) {
       setCount(1);
-      alert('담을 수 있는 수를 초과했습니다.');
+      toast.error('담을 수 있는 수를 초과했습니다.');
       return false;
     }
     return true;
+  }
+
+  function confirmGoCart(msg) {
+    confirmAlert({
+      title: msg,
+      buttons: [
+        {
+          label: '네',
+          onClick: () => { router.push(LINKS.CART); }
+        },
+        {
+          label: '아니오',
+          onClick: () => { return false; }
+        }
+      ]
+    });
   }
 
   function addCart() {
@@ -58,12 +77,12 @@ export default function ProductDetail() {
     if (!isCountValid()) {
       return;
     } else if (count <= 0) {
-      alert('수량을 입력해주세요');
+      toast.warn('수량을 입력해주세요');
       return;
     } else {
       if (typeof window !== 'undefined' && typeof window !== undefined) {
         if (localStorage.getItem('userId') === null) {
-          alert('로그인 해주세요.');
+          toast.error('로그인 해주세요.');
           router.push(LINKS.SIGNIN);
         }
       }
@@ -81,17 +100,14 @@ export default function ProductDetail() {
           if (res.success) {
             const confirmMsg =
               '장바구니에 성공적으로 담겼습니다. 장바구니페이지로 이동하시겠습니까?';
-            const confirmFlag = confirm(confirmMsg);
-            if (confirmFlag) {
-              router.push(LINKS.CART);
-            }
+            confirmGoCart(confirmMsg);
           } else {
             console.log(res);
-            alert(res.data.message);
+            toast.warn(res.data.message);
           }
         } else {
           // TODO 장바구니 실패했을때 경우의 수 추가
-          alert('이미 추가된 상품입니다.');
+          toast.warn('이미 추가된 상품입니다.');
         }
       });
     }
@@ -101,7 +117,7 @@ export default function ProductDetail() {
     let headers;
     if (typeof window !== 'undefined' && typeof window !== undefined) {
       if (localStorage.getItem('userId') === null) {
-        alert('로그인 해주세요.');
+        toast.warn('로그인 해주세요.');
         router.push(LINKS.SIGNIN);
       }
     }
@@ -199,6 +215,7 @@ export default function ProductDetail() {
                     onClickFunc={directOrder}
                     css={{ width: '49%', marginLeft: '1%' }}
                   />
+                  <Toast/>
                 </BtnSection>
               </ProductDetailTop>
             </ProductTopSection>

--- a/pages/seller/event/[id].js
+++ b/pages/seller/event/[id].js
@@ -10,6 +10,9 @@ import { getDateTime, getState } from '@utils/functions';
 import { PRIZE_TYPE, EVENT_TYPE } from '@utils/constants/types';
 import EventParticipant from '@components/event/EventParticipantList';
 import { useGetToken } from '@hooks/useGetToken';
+import { confirmAlert } from 'react-confirm-alert';
+import { toast } from 'react-toastify';
+import Toast from '@components/common/ToastPopup';
 
 export default function EventDetail() {
   const router = useRouter();
@@ -23,10 +26,10 @@ export default function EventDetail() {
   useEffect(() => {
     if (typeof window !== 'undefined' && typeof window !== undefined) {
       if (localStorage.getItem('userId') === null) {
-        alert('로그인 해주세요.');
+        toast('로그인 해주세요.');
         router.push('/signin');
       } else if (localStorage.getItem('role') === 'ROLE_USER') {
-        alert('판매자 페이지입니다.');
+        toast.warn('판매자 페이지입니다.');
         router.push('/');
       }
     }
@@ -41,7 +44,7 @@ export default function EventDetail() {
         if (res && res.data.id == eventId) {
           setEvent(res.data);
         } else {
-          alert('잘못된 요청입니다.');
+          toast.error('잘못된 요청입니다.');
           router.replace(`/seller/event/list`);
         }
       });
@@ -50,18 +53,35 @@ export default function EventDetail() {
 
   const deleteClickHandler = async (e) => {
     e.preventDefault();
-    DELETE(`/event/${eventId}`, {}).then((res) => {
-      if (res && res.success == true && confirm('삭제하시겠습니까?')) {
-        alert('삭제 되었습니다. ');
-        router.replace(`/seller/event/list`);
-      }
+
+    confirmAlert({
+      title: "등록한 이벤트를 취소하시겠습니까?",
+      buttons: [
+        {
+          label: '네',
+          onClick: () => {     
+            DELETE(`/event/${eventId}`, {}).then((res) => {
+              if (res && res.success == true) {
+                toast('삭제 되었습니다. ');
+                router.replace(`/seller/event/list`);
+              }
+            });
+          }
+        },
+        {
+          label: '아니오',
+          onClick: () => { return false; }
+        }
+      ]
     });
+
   };
 
   return (
     <SellerLayout>
       <SiteHead title={'Seller Office'} />
 
+      <Toast/>
       <section className="flex min-h-screen flex-col text-gray-600 body-font">
         <div className="container px-5 py-24 mx-auto">
           <Heading title="이벤트 상세" type="h1" />

--- a/pages/seller/event/[id].js
+++ b/pages/seller/event/[id].js
@@ -55,33 +55,34 @@ export default function EventDetail() {
     e.preventDefault();
 
     confirmAlert({
-      title: "등록한 이벤트를 취소하시겠습니까?",
+      title: '등록한 이벤트를 취소하시겠습니까?',
       buttons: [
         {
           label: '네',
-          onClick: () => {     
+          onClick: () => {
             DELETE(`/event/${eventId}`, {}).then((res) => {
               if (res && res.success == true) {
                 toast('삭제 되었습니다. ');
                 router.replace(`/seller/event/list`);
               }
             });
-          }
+          },
         },
         {
           label: '아니오',
-          onClick: () => { return false; }
-        }
-      ]
+          onClick: () => {
+            return false;
+          },
+        },
+      ],
     });
-
   };
 
   return (
     <SellerLayout>
       <SiteHead title={'Seller Office'} />
 
-      <Toast/>
+      <Toast />
       <section className="flex min-h-screen flex-col text-gray-600 body-font">
         <div className="container px-5 py-24 mx-auto">
           <Heading title="이벤트 상세" type="h1" />

--- a/pages/seller/event/new.js
+++ b/pages/seller/event/new.js
@@ -18,6 +18,8 @@ import { useGetToken } from '@hooks/useGetToken';
 import { ICON_WARNING_SIGN, ICON_CHECK } from '@utils/constants/icons';
 import ModalScheduler from '@components/event/ModalScheduler';
 import axios from 'axios';
+import { toast } from 'react-toastify';
+import Toast from '@components/common/ToastPopup';
 
 export default function Event() {
   const router = useRouter();
@@ -27,10 +29,10 @@ export default function Event() {
   useEffect(() => {
     if (typeof window !== 'undefined' && typeof window !== undefined) {
       if (localStorage.getItem('userId') === null) {
-        alert('로그인 해주세요.');
+        toast('로그인 해주세요.');
         router.push('/signin');
       } else if (localStorage.getItem('role') === 'ROLE_USER') {
-        alert('판매자 페이지입니다.');
+        toast.warn('판매자 페이지입니다.');
         router.push('/');
       }
     }
@@ -74,7 +76,7 @@ export default function Event() {
   // 선착순 이벤트 체크
   function checkFcfsPrize() {
     if (eventType === 'FCFS' && prizeList.length > 1) {
-      alert('선착순 이벤트는 한 가지 경품만 추가할 수 있습니다.');
+      toast.warn('선착순 이벤트는 한 가지 경품만 추가할 수 있습니다.');
       return true;
     }
     return false;
@@ -83,23 +85,23 @@ export default function Event() {
   // 이벤트 등록 validation check
   function validation(inputParams) {
     if (isEmpty(inputParams.title)) {
-      alert(EVENT_ERROR.NO_EVENT_TITLE);
+      toast.warn(EVENT_ERROR.NO_EVENT_TITLE);
       return false;
     }
     if (isEmpty(inputParams.descript)) {
-      alert(EVENT_ERROR.NO_DESCRIPT);
+      toast.warn(EVENT_ERROR.NO_DESCRIPT);
       return false;
     }
     if (isEmpty(inputParams.type)) {
-      alert(EVENT_ERROR.NO_EVENT_TYPE);
+      toast.warn(EVENT_ERROR.NO_EVENT_TYPE);
       return false;
     }
     if (isEmpty(inputParams.startAt)) {
-      alert(EVENT_ERROR.NO_START_AT);
+      toast.warn(EVENT_ERROR.NO_START_AT);
       return false;
     }
     if (isEmpty(inputParams.endAt)) {
-      alert(EVENT_ERROR.NO_END_AT);
+      toast.warn(EVENT_ERROR.NO_END_AT);
       return false;
     }
     if (
@@ -107,15 +109,15 @@ export default function Event() {
       inputParams.startAt <= new Date() ||
       inputParams.endAt <= new Date()
     ) {
-      alert(EVENT_ERROR.INVALID_DATE);
+      toast.warn(EVENT_ERROR.INVALID_DATE);
       return false;
     }
     if (prizeList.length < 1) {
-      alert(EVENT_ERROR.NO_PRIZE_LIST);
+      toast.warn(EVENT_ERROR.NO_PRIZE_LIST);
       return false;
     }
     if (fileList.length < 2) {
-      alert(EVENT_ERROR.NO_IMAGE);
+      toast.warn(EVENT_ERROR.NO_IMAGE);
       return;
     }
     if (checkFcfsPrize()) return false;
@@ -128,7 +130,7 @@ export default function Event() {
 
     let newVal = stockList[index].stock - 1;
     if (newVal < 1) {
-      alert('경품 수량은 한 개 이상 선택해야 합니다.');
+      toast.warn('경품 수량은 한 개 이상 선택해야 합니다.');
       return;
     }
     let copyArray = [...stockList];
@@ -145,7 +147,7 @@ export default function Event() {
     let copyArray = [...stockList];
 
     if (prizeList[index].stock < newVal) {
-      alert('등록 가능한 경품 수량을 초과했습니다.');
+      toast.warn('등록 가능한 경품 수량을 초과했습니다.');
       return;
     }
     copyArray[index] = { ...copyArray[index], stock: newVal };
@@ -444,7 +446,7 @@ export default function Event() {
         inputDtm: fromDTM.substr(0, 13) + ':00:00',
       }).then((res) => {
         if (res.data !== true) {
-          alert(res.message);
+          toast.warn(res.message);
           return;
         }
       });
@@ -484,14 +486,14 @@ export default function Event() {
     );
 
     if (arrIdx > -1 && prizeList[arrIdx].type === 'PRODUCT') {
-      alert('이미 같은 상품을 등록했습니다');
+      toast.warn('이미 같은 상품을 등록했습니다');
       return;
     }
 
     if (checkFcfsPrize()) return;
 
     if (productList[e.target.value].remains < 1) {
-      alert('경품으로 지급가능한 상품 재고가 부족합니다.');
+      toast.warn('경품으로 지급가능한 상품 재고가 부족합니다.');
       return;
     }
 
@@ -520,14 +522,14 @@ export default function Event() {
     const arrIdx = prizeList.findIndex((e) => e.id == couponList[idx].couponId);
 
     if (arrIdx > -1 && prizeList[arrIdx].type === 'COUPON') {
-      alert('이미 같은 쿠폰을 등록했습니다');
+      toast.warn('이미 같은 쿠폰을 등록했습니다');
       return;
     }
 
     if (checkFcfsPrize()) return;
 
     if (couponList[e.target.value].remains < 1) {
-      alert('발행가능한 쿠폰 수량이 부족합니다.');
+      toast.warn('발행가능한 쿠폰 수량이 부족합니다.');
       return;
     }
 

--- a/pages/signin.js
+++ b/pages/signin.js
@@ -7,6 +7,8 @@ import Link from 'next/link';
 import { Blue } from '@components/input/Button';
 import { FRONT_BASE_URL } from '@apis/api-config';
 import { LINKS } from '@utils/constants/links';
+import { toast } from 'react-toastify';
+import Toast from '@components/common/ToastPopup';
 
 export default function Signin() {
   const router = useRouter();
@@ -44,12 +46,12 @@ export default function Signin() {
           localStorage.setItem('sellerId', res.data.sellerId);
           localStorage.setItem('token', res.data.token);
 
-          alert('로그인 성공');
+          toast.success('로그인 성공');
           router.push(LINKS.MAIN);
         }
       })
       .catch(function (error) {
-        alert('로그인 실패');
+        toast.error('로그인 실패');
       });
   }
 
@@ -57,6 +59,7 @@ export default function Signin() {
     <CommerceLayout>
       <SiteHead title="로그인" />
 
+      <Toast/>
       <div className="bg-white py-6 sm:py-8 lg:py-12">
         <div className="max-w-screen-2xl px-4 md:px-8 mx-auto">
           <h2 className="text-gray-800 text-2xl lg:text-3xl font-bold text-center mb-4 md:mb-8">

--- a/pages/signin.js
+++ b/pages/signin.js
@@ -59,7 +59,7 @@ export default function Signin() {
     <CommerceLayout>
       <SiteHead title="로그인" />
 
-      <Toast/>
+      <Toast />
       <div className="bg-white py-6 sm:py-8 lg:py-12">
         <div className="max-w-screen-2xl px-4 md:px-8 mx-auto">
           <h2 className="text-gray-800 text-2xl lg:text-3xl font-bold text-center mb-4 md:mb-8">

--- a/pages/signup.js
+++ b/pages/signup.js
@@ -63,7 +63,7 @@ export default function Signup() {
           <h2 className="text-gray-800 text-2xl lg:text-3xl font-bold text-center mb-4 md:mb-8">
             회원가입
           </h2>
-          <Toast/>
+          <Toast />
 
           <form className="max-w-lg border rounded-lg mx-auto" method="post">
             <div className="flex flex-col gap-4 p-4 md:p-8">

--- a/pages/signup.js
+++ b/pages/signup.js
@@ -3,8 +3,9 @@ import useInput from '@hooks/useInput';
 import CommerceLayout from '@components/common/CommerceLayout';
 import { POST, POST_DATA } from '@apis/defaultApi';
 import { useRouter } from 'next/router';
-import { useState } from 'react';
 import { Blue } from '@components/input/Button';
+import { toast } from 'react-toastify';
+import Toast from '@components/common/ToastPopup';
 
 export default function Signup() {
   const router = useRouter();
@@ -34,7 +35,7 @@ export default function Signup() {
       !reqBody.password ||
       !reqBody.passwordConfirmation
     ) {
-      alert(`입력란을 모두 채워주세요.`);
+      toast.warn(`입력란을 모두 채워주세요.`);
       return;
     }
 
@@ -42,14 +43,14 @@ export default function Signup() {
       .then((res) => {
         console.log(res);
         if (res.success) {
-          alert('회원가입 성공');
+          toast.success('회원가입 성공');
           router.push({
             pathname: `./welcome/${res.data.name}`,
           });
         }
       })
       .catch(function (error) {
-        alert('회원가입 실패');
+        toast.error('회원가입 실패');
         return {};
       });
   }
@@ -62,6 +63,7 @@ export default function Signup() {
           <h2 className="text-gray-800 text-2xl lg:text-3xl font-bold text-center mb-4 md:mb-8">
             회원가입
           </h2>
+          <Toast/>
 
           <form className="max-w-lg border rounded-lg mx-auto" method="post">
             <div className="flex flex-col gap-4 p-4 md:p-8">


### PR DESCRIPTION
## 개요
브라우저의 기본 alert, confirm이 너무 날 것 그 자체라서.. 커스텀 alert와 confirm을 사용했습니다.

**실행 전 `npm i` 로 라이브러리 설치 먼저 부탁드립니다**

## 작업한 내용
- 마켓헤더 (로그인 / 로그아웃) 알림 팝업 추가
- 상품 화면에서 장바구니에 담을 때 알림 팝업 추가
- 장바구니에서 전체/단건 상품 삭제시 알림 팝업 추가
- 셀러오피스 - 이벤트 상세화면에서 삭제할 때, 이벤트 등록시 유효성 검증 알림 추가
- 로그인/회원가입 시 유효성 검증 알림 추가

## 리뷰 가이드
![image](https://user-images.githubusercontent.com/37797830/201538335-8737979c-f4b0-4e40-9f29-58883ce0f1e6.png)
![image](https://user-images.githubusercontent.com/37797830/201538366-b2dcd8e6-173b-44ae-9b85-1ef880e415a5.png)
