### PR TITLE
[feature/extractCouponCart] 장바구니 쿠폰 적용 알고리즘 변경

### DIFF
--- a/apis/defaultApi.js
+++ b/apis/defaultApi.js
@@ -6,6 +6,7 @@ const CONTENT_TYPE = 'application/json';
 
 axios.defaults.headers.common['Content-Type'] = CONTENT_TYPE;
 axios.defaults.headers.post['Content-Type'] = CONTENT_TYPE;
+axios.defaults.headers.patch['Content-Type'] = CONTENT_TYPE;
 
 export const GET = async (url, params, headers) => {
   let apiUrl = API_BASE_URL + url;

--- a/components/cart/CartContent.js
+++ b/components/cart/CartContent.js
@@ -5,49 +5,62 @@ import CartContentFooter from '@components/cart/CartContentFooter';
 import CartContentHeader from '@components/cart/CartContentHeader';
 
 export default function CartContent({
-  headers,
   cartBySellerDtoList,
   checkBoxStates,
   cartCheckBoxChange,
   cartInfoChange,
 }) {
-  const CommerceCartContentContainer = styled.div``;
-
-  const CartStoreSection = styled.div`
-    background-color: ${ThemeWhite};
-    border-radius: 6px;
-    margin-bottom: 20px;
-
-    @media (max-width: 1024px) {
-      padding: 10px 10px;
+  function ShowCartStore({ item }) {
+    let contentTotalPrice = 0;
+    const cartItemDtoList = item.cartItemDtoList;
+    if (cartItemDtoList && cartItemDtoList.length > 0) {
+      cartItemDtoList.forEach((item) => {
+        contentTotalPrice =
+          (contentTotalPrice + item.product.productPrice) * item.count;
+      });
     }
-    @media (min-width: 1024px) {
-      padding: 10px 20px;
-      margin: 30px 0;
-    }
-  `;
+
+    return (
+      <CartStoreSection className="cart-store-section">
+        <CartContentHeader storeName={item.storeName} />
+        <CartContentDetail
+          storeName={item.storeName}
+          cartItemDtoList={item.cartItemDtoList}
+          checkBoxStates={checkBoxStates}
+          cartCheckBoxChange={cartCheckBoxChange}
+          cartInfoChange={cartInfoChange}
+        />
+        <CartContentFooter
+          contentTotalPrice={contentTotalPrice}
+          storeName={item.storeName}
+          sellerId={item.sellerId}
+        />
+      </CartStoreSection>
+    );
+  }
 
   return (
     <CommerceCartContentContainer className="commerce-cart-content-container">
       {cartBySellerDtoList &&
         cartBySellerDtoList.map((item) => (
-          <CartStoreSection className="cart-store-section" key={item.sellerId}>
-            <CartContentHeader storeName={item.storeName} />
-            <CartContentDetail
-              headers={headers}
-              storeName={item.storeName}
-              cartItemDtoList={item.cartItemDtoList}
-              checkBoxStates={checkBoxStates}
-              cartCheckBoxChange={cartCheckBoxChange}
-              cartInfoChange={cartInfoChange}
-            />
-            <CartContentFooter
-              couponDto={item.couponDto}
-              storeName={item.storeName}
-              cartItemDtoList={item.cartItemDtoList}
-            />
-          </CartStoreSection>
+          <ShowCartStore item={item} key={item.sellerId} />
         ))}
     </CommerceCartContentContainer>
   );
 }
+
+const CommerceCartContentContainer = styled.div``;
+
+const CartStoreSection = styled.div`
+  background-color: ${ThemeWhite};
+  border-radius: 6px;
+  margin-bottom: 20px;
+
+  @media (max-width: 1024px) {
+    padding: 10px 10px;
+  }
+  @media (min-width: 1024px) {
+    padding: 10px 20px;
+    margin: 30px 0;
+  }
+`;

--- a/components/cart/CartContentDetail.js
+++ b/components/cart/CartContentDetail.js
@@ -1,17 +1,19 @@
+import { useContext } from 'react';
 import { useRouter } from 'next/router';
 import styled from '@emotion/styled';
 import { DELETE } from '@apis/defaultApi';
 import { ThemeGray1 } from '@utils/constants/themeColor';
 import CartProduct from '@components/cart/CartProduct';
+import { LoginHeaderContext } from '@pages/user/cart/index';
 
 export default function CartContentDetail({
-  headers,
   cartItemDtoList,
   checkBoxStates,
   cartCheckBoxChange,
   cartInfoChange,
 }) {
   const router = useRouter();
+  const headers = useContext(LoginHeaderContext);
 
   const ProductCheckSection = styled.div`
     position: relative;
@@ -51,6 +53,8 @@ export default function CartContentDetail({
 
   const CartDetailSection = styled.div`
     padding-top: 5px;
+    padding-bottom: 10px;
+    height: 100px;
     border-top: 1px solid white;
     border-bottom: 1px solid white;
     display: flex;

--- a/components/cart/CartContentDetail.js
+++ b/components/cart/CartContentDetail.js
@@ -54,10 +54,16 @@ export default function CartContentDetail({
   const CartDetailSection = styled.div`
     padding-top: 5px;
     padding-bottom: 10px;
-    height: 100px;
+
     border-top: 1px solid white;
     border-bottom: 1px solid white;
     display: flex;
+
+    @media (max-width: 1024px) {
+    }
+    @media (min-width: 1024px) {
+      height: 100px;
+    }
   `;
 
   const deleteCartItem = ({ input }) => {

--- a/components/cart/CartContentFooter.js
+++ b/components/cart/CartContentFooter.js
@@ -1,21 +1,31 @@
-import { useState } from 'react';
+import { useState, useContext, useEffect } from 'react';
 import styled from '@emotion/styled';
 import { SmallLineBlue } from '@components/input/Button';
 import CartCouponModal from '@components/cart/CartCouponModal';
+import { LoginHeaderContext } from '@pages/user/cart/index';
+import { GET_DATA } from '@apis/defaultApi';
 
 export default function CartContentFooter({
-  cartItemDtoList,
+  contentTotalPrice,
   storeName,
-  couponDto,
+  sellerId,
 }) {
+  const headers = useContext(LoginHeaderContext);
   const [modalState, setModalState] = useState(false);
-  let contentTotalPrice = 0;
-  if (cartItemDtoList && cartItemDtoList.length > 0) {
-    cartItemDtoList.forEach((item) => {
-      contentTotalPrice =
-        (contentTotalPrice + item.product.productPrice) * item.count;
+  const [couponArray, setCouponArray] = useState([]);
+
+  useEffect(() => {
+    GET_DATA(
+      `/coupon`,
+      { sellerId, totalFee: contentTotalPrice },
+      headers,
+    ).then((res) => {
+      console.log(res);
+      if (res) {
+        setCouponArray(res);
+      }
     });
-  }
+  }, []);
 
   const showModal = () => {
     setModalState(true);
@@ -32,9 +42,10 @@ export default function CartContentFooter({
       {modalState && (
         <CartCouponModal
           setModalState={setModalState}
-          couponDto={couponDto}
-          contentTotalPrice={contentTotalPrice}
           storeName={storeName}
+          sellerId={sellerId}
+          couponArray={couponArray}
+          contentTotalPrice={contentTotalPrice}
         />
       )}
     </ContentFooterSection>

--- a/components/cart/CartCouponModal.js
+++ b/components/cart/CartCouponModal.js
@@ -72,7 +72,7 @@ export default function CartCouponModal({
 }
 
 function ShowCouponTable({ couponDto, contentTotalPrice }) {
-  if (couponDto.length > 0) {
+  if (couponDto && couponDto.length > 0) {
     return (
       <CouponTable className="coupon-table">
         <thead className="text-m uppercase">
@@ -97,7 +97,8 @@ function ShowCouponTable({ couponDto, contentTotalPrice }) {
               <CouponTableRow
                 key={coupon.couponName + index}
                 couponName={coupon.couponName}
-                description={coupon.description}
+                type={coupon.type}
+                discountValue={coupon.discountValue}
                 discountPrice={coupon.totalFee}
                 contentTotalPrice={contentTotalPrice}
               />
@@ -112,23 +113,35 @@ function ShowCouponTable({ couponDto, contentTotalPrice }) {
 
 function CouponTableRow({
   couponName,
-  description,
+  type,
+  discountValue,
   discountPrice,
   contentTotalPrice,
 }) {
+  let description = '';
+  if (type === 'RATE') {
+    description = discountValue + '%';
+  } else if (type === 'AMOUNT') {
+    description = discountValue + '원';
+  } else {
+    description = discountValue;
+  }
+
+  description = description + ' 할인쿠폰';
+
   return (
     <tr className="bg-white border-b transition duration-300 ease-in-out hover:bg-gray-100">
       <td className="text-sm text-gray-900 font-light px-6 py-4 whitespace-nowrap">
         <span>{couponName}</span>
       </td>
       <td className="text-sm text-gray-900 font-light px-6 py-4 whitespace-nowrap">
-        {description} 할인쿠폰
+        {description}
       </td>
       <td className="text-sm text-gray-900 font-light px-6 py-4 whitespace-nowrap">
         {numberToMonetary(discountPrice)}
       </td>
       <td className="text-sm text-gray-900 font-light px-6 py-4 whitespace-nowrap">
-        {numberToMonetary(contentTotalPrice - discountPrice)}
+        {numberToMonetary(contentTotalPrice - discountPrice) || 0}
       </td>
     </tr>
   );

--- a/components/cart/CartCouponModal.js
+++ b/components/cart/CartCouponModal.js
@@ -39,33 +39,35 @@ export default function CartCouponModal({
   });
 
   return (
-    <ModalContainer ref={modalRef} className="modal-container">
-      <TopSection>
-        <button onClick={closeModal}>
-          <svg
-            width="12"
-            height="12"
-            viewBox="0 0 12 12"
-            fill={ThemeGray1}
-            preserveAspectRatio="xMidYMid meet"
-          >
-            <path
-              fillRule="nonzero"
-              d="M6 4.6L10.3.3l1.4 1.4L7.4 6l4.3 4.3-1.4 1.4L6 7.4l-4.3 4.3-1.4-1.4L4.6 6 .3 1.7 1.7.3 6 4.6z"
+    <BackgroundDIM>
+      <ModalContainer ref={modalRef} className="modal-container">
+        <TopSection>
+          <button onClick={closeModal}>
+            <svg
+              width="12"
+              height="12"
+              viewBox="0 0 12 12"
+              fill={ThemeGray1}
+              preserveAspectRatio="xMidYMid meet"
+            >
+              <path
+                fillRule="nonzero"
+                d="M6 4.6L10.3.3l1.4 1.4L7.4 6l4.3 4.3-1.4 1.4L6 7.4l-4.3 4.3-1.4-1.4L4.6 6 .3 1.7 1.7.3 6 4.6z"
+              />
+            </svg>
+          </button>
+        </TopSection>
+        <DetailSection>
+          <ModalTitleSection>{storeName}에서 사용가능한 쿠폰</ModalTitleSection>
+          <ModalTableSection>
+            <ShowCouponTable
+              couponDto={couponArray}
+              contentTotalPrice={contentTotalPrice}
             />
-          </svg>
-        </button>
-      </TopSection>
-      <DetailSection>
-        <ModalTitleSection>{storeName}에서 사용가능한 쿠폰</ModalTitleSection>
-        <ModalTableSection>
-          <ShowCouponTable
-            couponDto={couponArray}
-            contentTotalPrice={contentTotalPrice}
-          />
-        </ModalTableSection>
-      </DetailSection>
-    </ModalContainer>
+          </ModalTableSection>
+        </DetailSection>
+      </ModalContainer>
+    </BackgroundDIM>
   );
 }
 
@@ -131,6 +133,19 @@ function CouponTableRow({
     </tr>
   );
 }
+
+const BackgroundDIM = styled.div`
+  position: fixed;
+  background-color: rgba(0, 0, 0, 0.3);
+  width: 100vw;
+  height: 100vh;
+  z-index: 1000;
+  top: 0;
+  left: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
 
 const ModalContainer = styled.div`
   /* 최상단 위치 */

--- a/components/cart/CartCouponModal.js
+++ b/components/cart/CartCouponModal.js
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef } from 'react';
 import {
   ThemeGray1,
   ThemeWhite,
@@ -9,79 +9,10 @@ import { numberToMonetary } from '@utils/functions';
 
 export default function CartCouponModal({
   setModalState,
-  couponDto,
-  contentTotalPrice,
   storeName,
+  couponArray,
+  contentTotalPrice,
 }) {
-  const [couponArray, setCouponArray] = useState([]);
-
-  const addCouponArray = (parameter) => {
-    setCouponArray((couponArray) => [
-      ...couponArray,
-      {
-        couponName: parameter.couponName,
-        description: parameter.description,
-        discountPrice: parameter.discountPrice,
-      },
-    ]);
-  };
-
-  useEffect(() => {
-    if (
-      couponDto.rateCoupon &&
-      couponDto.amountCoupon &&
-      couponDto.amountCoupon.length + couponDto.rateCoupon.length > 0
-    ) {
-      const rateCouponList = couponDto.rateCoupon;
-      const amountCouponList = couponDto.amountCoupon;
-
-      let rateIndex = 0;
-      let amountIndex = 0;
-
-      for (
-        ;
-        rateIndex + amountIndex <
-        rateCouponList.length + amountCouponList.length;
-
-      ) {
-        let parameter = null;
-
-        if (rateCouponList.length > rateIndex) {
-          const nowCoupon = rateCouponList[rateIndex];
-          const nowPrice = (contentTotalPrice * nowCoupon.discountValue) / 100;
-          parameter = {
-            couponName: nowCoupon.couponName,
-            description: nowCoupon.discountValue + '%',
-            discountPrice: nowPrice,
-          };
-        }
-
-        if (amountCouponList.length > amountIndex) {
-          const nowCoupon = amountCouponList[amountIndex];
-          let nowPrice =
-            contentTotalPrice - nowCoupon.discountValue < 0
-              ? 0
-              : nowCoupon.discountValue;
-
-          if (parameter == null || parameter.discountPrice < nowPrice) {
-            parameter = {
-              couponName: nowCoupon.couponName,
-              description: nowCoupon.discountValue + '₩',
-              discountPrice: nowPrice,
-            };
-            amountIndex = amountIndex + 1;
-          } else {
-            rateIndex = rateIndex + 1;
-          }
-        }
-
-        if (parameter) {
-          addCouponArray(parameter);
-        }
-      }
-    }
-  }, []);
-
   const closeModal = () => {
     setModalState(false);
   };
@@ -100,12 +31,10 @@ export default function CartCouponModal({
 
     // 이벤트 핸들러 등록
     document.addEventListener('mousedown', handler);
-    // document.addEventListener('touchstart', handler); // 모바일 대응
 
     return () => {
       // 이벤트 핸들러 해제
       document.removeEventListener('mousedown', handler);
-      // document.removeEventListener('touchstart', handler); // 모바일 대응
     };
   });
 
@@ -162,12 +91,12 @@ function ShowCouponTable({ couponDto, contentTotalPrice }) {
         </thead>
         <tbody className="text-m">
           {couponDto &&
-            couponDto.map((coupon) => (
+            couponDto.map((coupon, index) => (
               <CouponTableRow
-                key={coupon.couponName}
+                key={coupon.couponName + index}
                 couponName={coupon.couponName}
                 description={coupon.description}
-                discountPrice={coupon.discountPrice}
+                discountPrice={coupon.totalFee}
                 contentTotalPrice={contentTotalPrice}
               />
             ))}

--- a/components/cart/CartHeader.js
+++ b/components/cart/CartHeader.js
@@ -2,6 +2,8 @@ import { useRouter } from 'next/router';
 import styled from '@emotion/styled';
 import { DELETE } from '@apis/defaultApi';
 import { SmallLineWhite } from '@components/input/Button';
+import { LoginHeaderContext } from '@pages/user/cart/index';
+import { useContext } from 'react';
 
 export default function CartHeader({
   totalCheckBoxChange,
@@ -9,9 +11,9 @@ export default function CartHeader({
   checkBoxStates,
   numberOfChekced,
   totalCheckBoxFlag,
-  headers,
 }) {
   const router = useRouter();
+  const headers = useContext(LoginHeaderContext);
 
   const CommerceCartHeaderContainer = styled.div`
     z-index: 100;

--- a/components/cart/CartProduct.js
+++ b/components/cart/CartProduct.js
@@ -1,19 +1,21 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useContext } from 'react';
 import { useRouter } from 'next/router';
 import styled from '@emotion/styled';
 import { PATCH } from '@apis/defaultApi';
 import { numberToMonetary } from '@utils/functions';
 import { SmallWhite } from '@components/input/Button';
 import Input from '@components/input/Input';
+import { LoginHeaderContext } from '@pages/user/cart/index';
 
 export default function CartProduct({
-  headers,
   cartItemId,
   product,
   count,
   setCountFunc,
 }) {
   const router = useRouter();
+  const headers = useContext(LoginHeaderContext);
+
   const goToProductDetail = (id) => {
     router.push({
       pathname: `/product/${id}`,

--- a/components/cart/EmptyCart.js
+++ b/components/cart/EmptyCart.js
@@ -40,7 +40,7 @@ export default function EmptyCart() {
         <Blue
           buttonText={'상품담으러가기'}
           onClickFunc={() => {
-            router.push(LINKS.MAIN);
+            router.push(LINKS.PRODUCT);
           }}
         />
       </EmptyButton>

--- a/components/coupon/UserSearchBar.js
+++ b/components/coupon/UserSearchBar.js
@@ -38,7 +38,7 @@ export default function UserSearchBar({ changeUserParentList }) {
   }
 
   function ShowUser() {
-    if (userList.length > 0) {
+    if (userList && userList.length > 0) {
       return (
         userList &&
         userList.map((user) => (

--- a/pages/seller/coupon/assign.js
+++ b/pages/seller/coupon/assign.js
@@ -82,7 +82,7 @@ export default function CouponAssign() {
 
     POST(`/coupon/assign`, reqBody)
       .then((res) => {
-        if (res.success) {
+        if (res && res.success) {
           alert('선택한 사용자에게 쿠폰이 정상적으로 지급되었습니다.');
           router.reload();
         } else if (res.message) {

--- a/pages/user/cart/index.js
+++ b/pages/user/cart/index.js
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, createContext } from 'react';
 import { useRouter } from 'next/router';
 import styled from '@emotion/styled';
 import { GET, POST } from '@apis/defaultApi';
@@ -11,6 +11,8 @@ import CartFooter from '@components/cart/CartFooter';
 import CartSidebar from '@components/cart/CartSidebar';
 import EmptyCart from '@components/cart/EmptyCart';
 import { useGetToken } from '@hooks/useGetToken';
+
+export const LoginHeaderContext = createContext('');
 
 export default function Cart() {
   const router = useRouter();
@@ -47,7 +49,6 @@ export default function Cart() {
     let getHeaders = useGetToken();
     setHeaders(getHeaders);
 
-    console.log('headers:', getHeaders);
     GET(`/cart/list`, null, getHeaders).then((res) => {
       console.log(res);
       if (res) {
@@ -269,37 +270,38 @@ export default function Cart() {
     `;
 
     return (
-      <CartSection className="cart-section">
-        <CartContainer>
-          <CartRow>
-            <CommerceCart className="commerce-cart">
-              <CartHeader
-                totalCheckBoxChange={totalCheckBoxChange}
-                cartBySellerDtoList={cartBySellerDtoList}
-                checkBoxStates={checkBoxStates}
-                numberOfChekced={numberOfChekced}
-                totalCheckBoxFlag={totalCheckBoxFlag}
-                headers={headers}
-              />
-              <CartContent
-                cartInfoChange={cartInfoChange}
-                cartCheckBoxChange={cartCheckBoxChange}
-                headers={headers}
-                cartBySellerDtoList={cartBySellerDtoList}
-                checkBoxStates={checkBoxStates}
-              />
-              <CartFooter length={cartItemCount} />
-            </CommerceCart>
-            <CartSidebarSection className="cart-sidebar-section">
-              <CartSidebar
-                GoToOrder={GoToOrder}
-                totalPrice={totalPrice}
-                numberOfChekced={numberOfChekced}
-              />
-            </CartSidebarSection>
-          </CartRow>
-        </CartContainer>
-      </CartSection>
+      <LoginHeaderContext.Provider value={headers}>
+        <CartSection className="cart-section">
+          <CartContainer>
+            <CartRow>
+              <CommerceCart className="commerce-cart">
+                <CartHeader
+                  totalCheckBoxChange={totalCheckBoxChange}
+                  cartBySellerDtoList={cartBySellerDtoList}
+                  checkBoxStates={checkBoxStates}
+                  numberOfChekced={numberOfChekced}
+                  totalCheckBoxFlag={totalCheckBoxFlag}
+                />
+                <CartContent
+                  cartInfoChange={cartInfoChange}
+                  cartCheckBoxChange={cartCheckBoxChange}
+                  headers={headers}
+                  cartBySellerDtoList={cartBySellerDtoList}
+                  checkBoxStates={checkBoxStates}
+                />
+                <CartFooter length={cartItemCount} />
+              </CommerceCart>
+              <CartSidebarSection className="cart-sidebar-section">
+                <CartSidebar
+                  GoToOrder={GoToOrder}
+                  totalPrice={totalPrice}
+                  numberOfChekced={numberOfChekced}
+                />
+              </CartSidebarSection>
+            </CartRow>
+          </CartContainer>
+        </CartSection>
+      </LoginHeaderContext.Provider>
     );
   }
 


### PR DESCRIPTION
## 개요

장바구니 쿠폰 적용 알고리즘 변경

## 작업한 내용

- 쿠폰 보는 알고리즘 제거를 위한 최적화
- 계산은 백에서하고 프런트에선 최대한 보여주기만 하자
- 모달 뒷편 회색 배경 추가

## 리뷰 가이드

페이지 멈추는지 안멈추는지 확인해주세요...

https://github.com/Lotte-Feelmycode/the-parabole-mono-be/pull/217 백엔드는 이 브랜치를 적용해야합니다.

## 테스트 결과

<img width="1785" alt="image" src="https://user-images.githubusercontent.com/52902010/201609125-806acd20-158d-4775-879f-743fb80421a7.png">


## 이슈번호

[#132]