### PR TITLE
Fix: 푸터 왼쪽으로 치우쳐져있던 오류 수정

### DIFF
--- a/components/common/Footer.js
+++ b/components/common/Footer.js
@@ -10,7 +10,7 @@ export default function Footer() {
   return (
     <>
       <footer className="text-gray-600 md:p-10 sm:p-4 body-font bg-gray-50">
-        <div className="container flex flex-wrap text-left sm:pt-4 text-center order-first">
+        <div className="container mx-auto flex flex-wrap text-left order-first">
           <DescriptionSection className="px-4 text-left">
             <a className="flex title-font font-medium items-center md:justify-start justify-center text-gray-900">
               <span className="text-xl">Parabole</span>


### PR DESCRIPTION
## 개요

푸터 왼쪽으로 치우쳐져있던 오류 수정

## 작업한 내용

푸터 왼쪽으로 치우쳐져있던 오류 수정

## 테스트 결과

<img width="1407" alt="image" src="https://user-images.githubusercontent.com/52902010/202423062-b451675d-2a61-480a-9d56-8930cc15b18c.png">

<img width="320" alt="image" src="https://user-images.githubusercontent.com/52902010/202423143-7930dbe1-f896-436e-8e34-36c3810a91c1.png">
