### PR TITLE
[Hotfix/event] 이벤트 오류 수정사항

### DIFF
--- a/components/Scheduler/scheduler.js
+++ b/components/Scheduler/scheduler.js
@@ -34,8 +34,8 @@ export default function EventScheduler({ input }) {
           defaultCurrentViewName="Week"
         />
 
-        <DayView startDayHour={0} endDayHour={23} cellDuration={60} />
-        <WeekView startDayHour={0} endDayHour={23} cellDuration={60} />
+        <DayView startDayHour={8} endDayHour={24} cellDuration={60} />
+        <WeekView startDayHour={8} endDayHour={24} cellDuration={60} />
 
         <Toolbar />
         <ViewSwitcher />

--- a/components/event/Event.js
+++ b/components/event/Event.js
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 import { useRouter } from 'next/router';
-import { EVENT_TYPE } from '@utils/constants/types';
+import { EVENT_TYPE, EVENT_STATUS } from '@utils/constants/types';
 import { getDateTime, getState } from '@utils/functions';
 import { NO_IMAGE } from '@utils/constants/images';
 
@@ -10,6 +10,7 @@ import {
   ThemeWhite,
   ThemeBlack,
   MainBlue,
+  MainPink, 
 } from '@utils/constants/themeColor';
 
 export default function Event({ event }) {
@@ -34,7 +35,15 @@ export default function Event({ event }) {
           <TitleSection className="title-section">{event.title}</TitleSection>
           <TypeSection className="type-section">
             <StoreNameSection>{event.storeName}</StoreNameSection>
-            <Tags>{getState(EVENT_TYPE, event.type)}</Tags>
+            <div className="flex flex-row justify-end">
+              <TypeTag>{getState(EVENT_TYPE, event.type)}</TypeTag>
+              {event && event.status && event.status === 1 ? (
+                <OpenedTag>{getState(EVENT_STATUS, event.status)}</OpenedTag>
+              ) : (
+                <ClosedTag>{getState(EVENT_STATUS, event.status)}</ClosedTag>
+              )}
+            </div>
+
           </TypeSection>
           <TimeSection className="time-section">
             {getDateTime(event.startAt)}
@@ -130,11 +139,30 @@ const TimeSection = styled.div`
   }
 `;
 
-const Tags = styled.span`
+const TypeTag = styled.span`
   background-color: ${ThemeBlack};
   color: ${ThemeWhite};
   font-size: 1rem;
-  margin-left: auto;
+  margin-left: 5px;
+  padding: 0.5rem 1rem;
+  border-radius: 3rem;
+`;
+
+const ClosedTag = styled.span`
+  background-color: ${ThemeWhite};
+  color: ${ThemeBlack};
+  font-size: 1rem;
+  margin-left: 5px;
+  padding: 0.5rem 1rem;
+  border-radius: 3rem;
+`;
+
+
+const OpenedTag = styled.span`
+  background-color: ${MainPink};
+  color: ${ThemeWhite};
+  font-size: 1rem;
+  margin-left: 5px;
   padding: 0.5rem 1rem;
   border-radius: 3rem;
 `;

--- a/components/event/EventSampleModal.js
+++ b/components/event/EventSampleModal.js
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import { useRef } from 'react';
+import { useRef, useEffect } from 'react';
 import CloseButton from '@components/input/CloseButton';
 import EventInfo from '@components/event/EvenInfo';
 import EventPrizeContainer from '@components/event/EventPrizeContainer';
@@ -11,6 +11,26 @@ export default function EventSampleModal({ setModalState, event }) {
     e.preventDefault();
     setModalState(false);
   };
+
+  useEffect(() => {
+    const handler = () => {
+      // mousedown 이벤트가 발생한 영역이 모달창이 아닐 때, 모달창 제거 처리
+      if (modalRef.current && !modalRef.current.contains(event.target)) {
+        setModalState(false);
+      }
+    };
+
+    // 이벤트 핸들러 등록
+    document.addEventListener('mouseup', handler);
+    document.addEventListener('touchstart', handler); // 모바일 대응
+
+    return () => {
+      // 이벤트 핸들러 해제
+      document.removeEventListener('mouseup', handler);
+      document.removeEventListener('touchstart', handler); // 모바일 대응
+    };
+  });
+
   return (
     <BackgroundDIM>
       <ModalContainer ref={modalRef} className="modal-container">

--- a/pages/seller/event/new.js
+++ b/pages/seller/event/new.js
@@ -48,11 +48,10 @@ export default function Event() {
   const [prizeList, setprizeList] = useState([]);
   const [scheduleList, setScheduleList] = useState([]);
 
-  const [fileList, setFileList] = useState([]); // 업로드한 파일들을 저장하는 배열
+  const [fileList, setFileList] = useState([]);
   const [title, onChangeTitle] = useInput('');
   const [descript, onChangeDescript] = useInput('');
   const [eventType, setEventType] = useState('');
-  const [chatOpen, onChatOpen] = useCheck(true);
   const [startAt, setStartAt] = useState();
   const [endAt, setEndAt] = useState();
   const [stockList, setStockList] = useState([]);
@@ -262,9 +261,6 @@ export default function Event() {
                       혜택
                     </th>
                     <th scope="col" className="py-2 px-2">
-                      쿠폰 시작일
-                    </th>
-                    <th scope="col" className="py-2 px-2">
                       쿠폰 만료일
                     </th>
                     <th scope="col" className="py-2 px-2">
@@ -286,7 +282,6 @@ export default function Event() {
                             ? coupon.discountValue + '%'
                             : numberToMonetary(coupon.discountValue) + '원'}
                         </td>
-                        <td className="py-4 w-20">{getDate(coupon.validAt)}</td>
                         <td className="py-4 w-20">
                           {getDate(coupon.expiresAt)}
                         </td>


### PR DESCRIPTION
- 판매자 오피스 이벤트 상세화면 > 미리보기에서 모달창 끌 수 있도록 이벤트 핸들러 추가했습니다.
- (mousedown이벤트라서.. 스크롤만 내리려고해도 모달창이 꺼지길래 CloseButton 추가해놓고 이벤트 빼놓은건데 화면이 커서 버튼이 잘 안보이는 관계로 우선 다시 이벤트 핸들러 추가합니다 ㅠㅠ)
- 이벤트 목록에서 진행상황 파악이 어려워 표시하였습니다.
- 이벤트 스케쥴러 조회가능한 시간을 8시 ~ 24시로 변경했습니다. 선착순 이벤트는 이 시간내에 등록해야합니다.
- 쿠폰 데이터 시작일자 사용안하는 것으로 보여져 컬럼 삭제했습니다. 
@jungeu1509 @chd830 @choihyeongjun @daeunchung 